### PR TITLE
Include browser extension in GitHub releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,12 +37,16 @@ jobs:
           cd build
           zip -r MacWhisperAuto.app.zip MacWhisperAuto.app
 
+      - name: Zip browser extension
+        run: zip -r MacWhisperAuto-Extension.zip Extension/
+
       - name: Create GitHub Release
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
           gh release create "${{ steps.version.outputs.tag }}" \
             build/MacWhisperAuto.app.zip \
+            MacWhisperAuto-Extension.zip \
             --title "MacWhisperAuto ${{ steps.version.outputs.tag }}" \
             --generate-notes \
             --target "${{ github.sha }}" \


### PR DESCRIPTION
## Summary
- Adds a step to zip the `Extension/` directory into `MacWhisperAuto-Extension.zip`
- Uploads both the app bundle and browser extension as release assets
- Users no longer need to clone the repo to get the browser extension

## Test plan
- [ ] Trigger a release (push to main or tag `v*`) and verify both `MacWhisperAuto.app.zip` and `MacWhisperAuto-Extension.zip` appear in the release assets