### PR TITLE
Make main branch pushes create real releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -45,5 +45,4 @@ jobs:
             build/MacWhisperAuto.app.zip \
             --title "MacWhisperAuto ${{ steps.version.outputs.tag }}" \
             --generate-notes \
-            --target "${{ github.sha }}" \
-            ${{ startsWith(github.ref, 'refs/tags/') && ' ' || '--prerelease' }}
+            --target "${{ github.sha }}"


### PR DESCRIPTION
## Summary
- Remove `--prerelease` flag from release workflow so pushes to main create real releases instead of prereleases

## Test plan
- [ ] Merge to main and verify the resulting GitHub release is not marked as prerelease