### PR TITLE
Use semver-generator for semantic versioning

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,8 +3,6 @@ name: Release
 on:
   push:
     branches: [main]
-    tags:
-      - 'v*'
 
 permissions:
   contents: write
@@ -20,14 +18,11 @@ jobs:
 
       - name: Generate version
         id: version
-        run: |
-          if [[ "${{ github.ref }}" == refs/tags/v* ]]; then
-            echo "tag=${{ github.ref_name }}" >> "$GITHUB_OUTPUT"
-          else
-            TAG="v0.0.$(git rev-list --count HEAD)-${GITHUB_SHA::7}"
-            echo "tag=$TAG" >> "$GITHUB_OUTPUT"
-            git tag "$TAG"
-          fi
+        uses: lukaszraczylo/semver-generator@v1
+        with:
+          config_file: semver.yaml
+          repository_local: true
+          strict: true
 
       - name: Build .app bundle
         run: scripts/build.sh
@@ -44,10 +39,9 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
-          gh release create "${{ steps.version.outputs.tag }}" \
+          gh release create "v${{ steps.version.outputs.semantic_version }}" \
             build/MacWhisperAuto.app.zip \
             MacWhisperAuto-Extension.zip \
-            --title "MacWhisperAuto ${{ steps.version.outputs.tag }}" \
+            --title "MacWhisperAuto v${{ steps.version.outputs.semantic_version }}" \
             --generate-notes \
-            --target "${{ github.sha }}" \
-            ${{ startsWith(github.ref, 'refs/tags/') && ' ' || '--prerelease' }}
+            --target "${{ github.sha }}"

--- a/semver.yaml
+++ b/semver.yaml
@@ -1,0 +1,22 @@
+version: 1
+force:
+  major: 0
+  minor: 1
+  patch: 0
+wording:
+  patch:
+    - fix
+    - update
+    - pin
+    - relax
+    - revert
+  minor:
+    - add
+    - implement
+    - include
+    - change
+    - improve
+    - feature
+  major:
+    - breaking
+    - major


### PR DESCRIPTION
## Summary
- Replace commit-count based version scheme (`v0.0.N-sha`) with [lukaszraczylo/semver-generator](https://github.com/lukaszraczylo/semver-generator)
- Add `semver.yaml` config that derives version bumps from commit message keywords (fix/update → patch, add/implement → minor, breaking → major)
- Remove manual tag creation and prerelease logic from release workflow

## Test plan
- [ ] Merge to main and verify semver-generator produces a valid version tag
- [ ] Verify GitHub release is created with the correct semver version