### PR TITLE
Add version checking and CI version stamping

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,6 +25,8 @@ jobs:
           strict: true
 
       - name: Build .app bundle
+        env:
+          VERSION: ${{ steps.version.outputs.semantic_version }}
         run: scripts/build.sh
 
       - name: Zip .app bundle

--- a/Sources/App/AppDelegate.swift
+++ b/Sources/App/AppDelegate.swift
@@ -75,40 +75,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         appState.addActivity("Detection started")
 
         // Set up WebSocket server for browser extension
-        let messageHandler = ExtensionMessageHandler(
-            onSignal: { [weak coord] signal in
-                coord?.handleSignal(signal)
-            },
-            onConnectionStateChanged: { [weak appState] connected in
-                Task { @MainActor in
-                    appState?.extensionConnected = connected
-                }
-            }
-        )
-        extensionMessageHandler = messageHandler
-
-        let wsServer = WebSocketServer()
-        wsServer.onMessage = { [weak messageHandler] data in
-            messageHandler?.handleMessage(data)
-        }
-        wsServer.onClientConnected = { [weak messageHandler] in
-            messageHandler?.onConnectionStateChanged(true)
-        }
-        wsServer.onClientDisconnected = { [weak wsServer, weak appState] in
-            let stillConnected = wsServer?.hasConnections ?? false
-            Task { @MainActor in
-                appState?.extensionConnected = stillConnected
-            }
-        }
-        wsServer.onError = { [weak appState] error in
-            Task { @MainActor in
-                // WebSocket failure is non-fatal - native detection still works
-                DetectionLogger.shared.error(.webSocket, "WebSocket error: \(error)")
-                appState?.addActivity("Browser extension unavailable (WebSocket error)")
-            }
-        }
-        webSocketServer = wsServer
-        wsServer.start()
+        setupWebSocket(coordinator: coord)
 
         // Set up menu bar UI (pass permissionManager for onboarding)
         let sbc = StatusBarController(
@@ -140,6 +107,64 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
 
         // Launch MacWhisper in background so it's ready when a meeting is detected.
         macWhisperController.launchInBackground()
+
+        // Check for app updates in the background
+        checkForAppUpdate()
+    }
+
+    private func setupWebSocket(coordinator coord: DetectionCoordinator) {
+        let messageHandler = ExtensionMessageHandler(
+            onSignal: { [weak coord] signal in
+                coord?.handleSignal(signal)
+            },
+            onConnectionStateChanged: { [weak appState] connected in
+                Task { @MainActor in
+                    appState?.extensionConnected = connected
+                }
+            },
+            onExtensionVersionReceived: { [weak appState] version in
+                Task { @MainActor in
+                    appState?.extensionVersion = version
+                }
+            }
+        )
+        extensionMessageHandler = messageHandler
+
+        let wsServer = WebSocketServer()
+        wsServer.onMessage = { [weak messageHandler] data in
+            messageHandler?.handleMessage(data)
+        }
+        wsServer.onClientConnected = { [weak messageHandler] in
+            messageHandler?.onConnectionStateChanged(true)
+        }
+        wsServer.onClientDisconnected = { [weak wsServer, weak appState] in
+            let stillConnected = wsServer?.hasConnections ?? false
+            Task { @MainActor in
+                appState?.extensionConnected = stillConnected
+            }
+        }
+        wsServer.onError = { [weak appState] error in
+            Task { @MainActor in
+                DetectionLogger.shared.error(.webSocket, "WebSocket error: \(error)")
+                appState?.addActivity("Browser extension unavailable (WebSocket error)")
+            }
+        }
+        webSocketServer = wsServer
+        wsServer.start()
+    }
+
+    private func checkForAppUpdate() {
+        Task {
+            if let latest = await VersionChecker.fetchLatestVersion() {
+                await MainActor.run {
+                    appState.latestReleaseVersion = latest
+                    if appState.appUpdateAvailable {
+                        DetectionLogger.shared.lifecycle("Update available: v\(latest) (current: v\(appState.appVersion))")
+                        appState.addActivity("Update available: v\(latest)")
+                    }
+                }
+            }
+        }
     }
 
     func applicationWillTerminate(_ notification: Notification) {

--- a/Sources/Core/AppState.swift
+++ b/Sources/Core/AppState.swift
@@ -10,6 +10,21 @@ final class AppState {
     var permissionsGranted: Bool = false
     var extensionConnected: Bool = false
 
+    // Version tracking
+    let appVersion: String = Bundle.main.object(forInfoDictionaryKey: "CFBundleShortVersionString") as? String ?? "0.0.0"
+    var extensionVersion: String?
+    var latestReleaseVersion: String?
+
+    var appUpdateAvailable: Bool {
+        guard let latest = latestReleaseVersion else { return false }
+        return latest.compare(appVersion, options: .numeric) == .orderedDescending
+    }
+
+    var extensionVersionMismatch: Bool {
+        guard let extVer = extensionVersion else { return false }
+        return extVer != appVersion
+    }
+
     var showOnboarding: Bool { !permissionsGranted }
 
     var isRecording: Bool {

--- a/Sources/Networking/ExtensionMessageHandler.swift
+++ b/Sources/Networking/ExtensionMessageHandler.swift
@@ -12,6 +12,7 @@ import os
 final class ExtensionMessageHandler: Sendable {
     let onSignal: @Sendable (MeetingSignal) -> Void
     let onConnectionStateChanged: @Sendable (Bool) -> Void
+    let onExtensionVersionReceived: @Sendable (String) -> Void
 
     /// Only emit inactive after no connection has reported meetings for this long.
     /// Must exceed the heartbeat interval (~20s) to survive interleaved heartbeats.
@@ -22,10 +23,12 @@ final class ExtensionMessageHandler: Sendable {
 
     init(
         onSignal: @escaping @Sendable (MeetingSignal) -> Void,
-        onConnectionStateChanged: @escaping @Sendable (Bool) -> Void
+        onConnectionStateChanged: @escaping @Sendable (Bool) -> Void,
+        onExtensionVersionReceived: @escaping @Sendable (String) -> Void = { _ in }
     ) {
         self.onSignal = onSignal
         self.onConnectionStateChanged = onConnectionStateChanged
+        self.onExtensionVersionReceived = onExtensionVersionReceived
     }
 
     /// Process a raw WebSocket message (JSON data).
@@ -50,6 +53,11 @@ final class ExtensionMessageHandler: Sendable {
 
     /// Heartbeat reconstructs full state from a single message (FR38).
     private func handleHeartbeat(_ json: [String: Any]) {
+        // Extract extension version from heartbeat
+        if let version = json["extension_version"] as? String {
+            onExtensionVersionReceived(version)
+        }
+
         guard let meetings = json["active_meetings"] as? [[String: Any]] else {
             emitInactiveIfGracePeriodElapsed()
             return

--- a/Sources/Networking/VersionChecker.swift
+++ b/Sources/Networking/VersionChecker.swift
@@ -1,0 +1,33 @@
+import Foundation
+
+/// Checks the latest stable release version from GitHub.
+/// Returns nil on any failure (no network, rate limited, no releases).
+enum VersionChecker {
+    private static let releasesURL = URL(string: "https://api.github.com/repos/chrisns/MacWhisperAuto/releases/latest")!
+
+    static func fetchLatestVersion() async -> String? {
+        do {
+            var request = URLRequest(url: releasesURL)
+            request.setValue("application/vnd.github+json", forHTTPHeaderField: "Accept")
+            request.timeoutInterval = 10
+
+            let (data, response) = try await URLSession.shared.data(for: request)
+
+            guard let httpResponse = response as? HTTPURLResponse,
+                  httpResponse.statusCode == 200 else {
+                return nil
+            }
+
+            guard let json = try JSONSerialization.jsonObject(with: data) as? [String: Any],
+                  let tagName = json["tag_name"] as? String else {
+                return nil
+            }
+
+            // Strip "v" prefix if present
+            return tagName.hasPrefix("v") ? String(tagName.dropFirst()) : tagName
+        } catch {
+            DetectionLogger.shared.webSocket("Version check failed: \(error.localizedDescription)")
+            return nil
+        }
+    }
+}

--- a/Sources/UI/StatusMenuView.swift
+++ b/Sources/UI/StatusMenuView.swift
@@ -185,7 +185,34 @@ struct StatusMenuView: View {
                 .cornerRadius(6)
             }
 
+            if appState.extensionVersionMismatch {
+                HStack(spacing: 6) {
+                    Image(systemName: "exclamationmark.triangle.fill")
+                        .foregroundStyle(.orange)
+                    Text("Extension v\(appState.extensionVersion ?? "?") does not match app v\(appState.appVersion)")
+                        .font(.caption2)
+                }
+                .padding(8)
+                .background(.orange.opacity(0.08))
+                .cornerRadius(6)
+            }
+
+            if appState.appUpdateAvailable {
+                HStack(spacing: 6) {
+                    Image(systemName: "arrow.down.circle.fill")
+                        .foregroundStyle(.blue)
+                    Text("v\(appState.latestReleaseVersion ?? "") available (you have v\(appState.appVersion))")
+                        .font(.caption2)
+                }
+                .padding(8)
+                .background(.blue.opacity(0.08))
+                .cornerRadius(6)
+            }
+
             HStack {
+                Text("v\(appState.appVersion)")
+                    .font(.caption2)
+                    .foregroundStyle(.tertiary)
                 Spacer()
                 Button("Quit") {
                     NSApplication.shared.terminate(nil)

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -7,6 +7,14 @@ APP_BUNDLE="$BUILD_DIR/MacWhisperAuto.app"
 CONTENTS="$APP_BUNDLE/Contents"
 MACOS="$CONTENTS/MacOS"
 
+# VERSION env var: strip v prefix and any -suffix (e.g. v1.2.3-abc1234 -> 1.2.3)
+if [ -n "${VERSION:-}" ]; then
+    SEMVER="$(echo "$VERSION" | sed 's/^v//; s/-.*//')"
+    echo "==> Version override: $SEMVER"
+else
+    SEMVER=""
+fi
+
 echo "==> Building with swift build (release)..."
 cd "$ROOT"
 swift build -c release
@@ -23,6 +31,28 @@ mkdir -p "$MACOS"
 
 cp "$EXECUTABLE" "$MACOS/MacWhisperAuto"
 cp "$ROOT/Resources/Info.plist" "$CONTENTS/Info.plist"
+
+# Stamp version into app Info.plist
+if [ -n "$SEMVER" ]; then
+    echo "==> Stamping version $SEMVER into Info.plist..."
+    plutil -replace CFBundleShortVersionString -string "$SEMVER" "$CONTENTS/Info.plist"
+fi
+
+# Stamp version into Extension files
+if [ -n "$SEMVER" ]; then
+    echo "==> Stamping version $SEMVER into Extension files..."
+    # Update manifest.json version
+    MANIFEST="$ROOT/Extension/manifest.json"
+    if [ -f "$MANIFEST" ]; then
+        sed -i '' "s/\"version\": \".*\"/\"version\": \"$SEMVER\"/" "$MANIFEST"
+    fi
+
+    # Update background.js EXTENSION_VERSION constant
+    BG_JS="$ROOT/Extension/background.js"
+    if [ -f "$BG_JS" ]; then
+        sed -i '' "s/const EXTENSION_VERSION = '.*'/const EXTENSION_VERSION = '$SEMVER'/" "$BG_JS"
+    fi
+fi
 
 echo "==> Signing (ad-hoc) with entitlements..."
 codesign --force --sign - \


### PR DESCRIPTION
## Summary

- App checks its version against the latest stable GitHub release and shows a blue "update available" banner
- Browser extension version is extracted from WebSocket heartbeats; orange warning shown on version mismatch
- Build script (`scripts/build.sh`) accepts `VERSION` env var, sanitizes to semver, and stamps into Info.plist, `manifest.json`, and `background.js`
- CI workflow passes the release tag as `VERSION` and includes the Extension folder as a separate zip in release artifacts
- App version displayed in menu bar popover footer

## Test plan

- [ ] `scripts/build.sh` without `VERSION` — builds as before using Info.plist defaults
- [ ] `VERSION=v1.2.3-abc1234 scripts/build.sh` — verify built Info.plist has `1.2.3`, Extension files updated
- [ ] Launch app — version appears in footer next to Quit
- [ ] No stable GitHub releases → no "update available" banner
- [ ] Extension connected with matching version → no mismatch banner
- [ ] Extension connected with different version → orange mismatch warning
- [ ] No extension → no mismatch banner (existing "not connected" warning handles this)
- [ ] No network → no crash, no banner