### PR TITLE
Add Homebrew tap distribution

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,6 +32,10 @@ jobs:
           cd build
           zip -r MacWhisperAuto.app.zip MacWhisperAuto.app
 
+      - name: Compute SHA256
+        id: sha256
+        run: echo "hash=$(shasum -a 256 build/MacWhisperAuto.app.zip | awk '{print $1}')" >> "$GITHUB_OUTPUT"
+
       - name: Zip browser extension
         run: zip -r MacWhisperAuto-Extension.zip Extension/
 
@@ -45,3 +49,12 @@ jobs:
             --title "MacWhisperAuto v${{ steps.version.outputs.semantic_version }}" \
             --generate-notes \
             --target "${{ github.sha }}"
+
+      - name: Update Homebrew tap
+        env:
+          GH_TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN }}
+        run: |
+          gh workflow run update.yml \
+            --repo chrisns/homebrew-macwhisperauto \
+            --field version="${{ steps.version.outputs.semantic_version }}" \
+            --field sha256="${{ steps.sha256.outputs.hash }}"

--- a/README.md
+++ b/README.md
@@ -125,6 +125,14 @@ The state machine is pure -- it returns side effects (`startRecording`, `stopRec
 
 ## Installation
 
+### Homebrew (recommended)
+
+```bash
+brew install --cask chrisns/macwhisperauto/macwhisperauto
+```
+
+MacWhisperAuto is ad-hoc signed and not notarized. On first launch, macOS Gatekeeper will block it — allow it in **System Settings > Privacy & Security > Security > Open Anyway**.
+
 ### Build from Source
 
 ```bash


### PR DESCRIPTION
## Summary
- Add SHA256 computation and Homebrew tap dispatch to the release workflow
- Add Homebrew install instructions to README as the recommended method
- Tap repo created at [chrisns/homebrew-macwhisperauto](https://github.com/chrisns/homebrew-macwhisperauto) with cask definition and auto-update workflow

## How it works
1. Release workflow computes SHA256 of the ZIP artifact
2. After creating the GitHub release, it dispatches `update.yml` in the tap repo via `gh workflow run`
3. The tap workflow updates the cask version and SHA256, then commits and pushes

## Required setup
- Create a `HOMEBREW_TAP_TOKEN` secret in this repo (GitHub PAT with `repo` + `workflow` scopes)

## Test plan
- [ ] Create `HOMEBREW_TAP_TOKEN` secret
- [ ] Merge this PR → verify release creates clean semver tag
- [ ] Verify tap repo cask is updated with correct version and SHA256
- [ ] `brew install --cask chrisns/macwhisperauto/macwhisperauto` installs successfully
- [ ] `brew upgrade --cask macwhisperauto` picks up new versions