### PR TITLE
Suppress Slack huddle false positives via IOPM + sustained UDP gate

### DIFF
--- a/Sources/Detection/SlackDetector.swift
+++ b/Sources/Detection/SlackDetector.swift
@@ -1,20 +1,32 @@
+import AppKit
 import Foundation
+import IOKit.pwr_mgt
 import os
 
-/// Detects Slack huddles via two complementary signals:
-/// 1. CGWindowList: "huddle" in window titles (needs Screen Recording)
-/// 2. Network UDP: Count of UDP sockets for Slack process (no permissions needed)
+/// Detects Slack huddles via two complementary paths:
+/// 1. CGWindowList: "huddle" in window titles (needs Screen Recording permission).
+/// 2. Network UDP + IOPM assertion (AND-gated): Slack holds many UDP sockets AND
+///    a PreventUserIdleDisplaySleep/SystemSleep assertion during huddles. The UDP
+///    count must stay above threshold for several consecutive polls to filter
+///    transient bursts from notification sounds, voice-message previews, etc.
 final class SlackDetector: MeetingDetector, WindowListConsumer, @unchecked Sendable {
     private let onSignal: @Sendable (MeetingSignal) -> Void
     private let _isEnabled = OSAllocatedUnfairLock(initialState: false)
     private let _lastActive = OSAllocatedUnfairLock(initialState: false)
 
-    // Network UDP state
-    private let _lastNetworkActive = OSAllocatedUnfairLock(initialState: false)
+    // Poll-queue-confined state (only touched from pollQueue)
     private var pollTimer: DispatchSourceTimer?
     private let pollQueue = DispatchQueue(label: "com.macwhisperauto.slack.poll")
+    private var consecutiveOverThreshold = 0
+    private var lastNetworkActive = false
+    private var peakUDPDuringActive = 0
+    private var activeSince: Date?
+
     private static let pollInterval: TimeInterval = 3.0
-    private static let udpSocketThreshold = 2
+    private static let udpSocketThreshold = 4          // fire when count > 4 (i.e. >= 5)
+    private static let sustainedPollsRequired = 2      // ~3-6s sustained over-threshold
+    private static let slackBundleID = "com.tinyspeck.slackmacgap"
+    private static let falsePositiveDurationCutoff: TimeInterval = 60.0
 
     var isEnabled: Bool { _isEnabled.withLock { $0 } }
 
@@ -28,7 +40,7 @@ final class SlackDetector: MeetingDetector, WindowListConsumer, @unchecked Senda
 
     func start() {
         _isEnabled.withLock { $0 = true }
-        startNetworkPolling()
+        startPolling()
         DetectionLogger.shared.detection("SlackDetector started", platform: .slack)
     }
 
@@ -39,43 +51,101 @@ final class SlackDetector: MeetingDetector, WindowListConsumer, @unchecked Senda
         DetectionLogger.shared.detection("SlackDetector stopped", platform: .slack)
     }
 
-    // MARK: - Network UDP Detection
+    // MARK: - Combined UDP + IOPM polling
 
-    private func startNetworkPolling() {
+    private func startPolling() {
         let timer = DispatchSource.makeTimerSource(queue: pollQueue)
         timer.schedule(deadline: .now(), repeating: Self.pollInterval, leeway: .milliseconds(500))
         timer.setEventHandler { [weak self] in
-            self?.pollNetworkConnections()
+            self?.pollOnce()
         }
         timer.resume()
         pollTimer = timer
     }
 
-    private func pollNetworkConnections() {
+    private func pollOnce() {
         guard isEnabled else { return }
-        let udpCount = Self.countSlackUDPSockets()
-        let active = udpCount > Self.udpSocketThreshold
 
-        let lastActive = _lastNetworkActive.withLock { old -> Bool in
-            let was = old; old = active; return was
+        let udpCount = Self.countSlackUDPSockets()
+        let overThreshold = udpCount > Self.udpSocketThreshold
+        let (iopmActive, assertionNames) = Self.slackAssertions()
+
+        if overThreshold {
+            consecutiveOverThreshold += 1
+        } else {
+            consecutiveOverThreshold = 0
         }
-        if active != lastActive {
+        let sustained = consecutiveOverThreshold >= Self.sustainedPollsRequired
+        let active = sustained && iopmActive
+
+        // Per-poll diagnostic (debug level) - so Phase 2 tuning is data-driven.
+        DetectionLogger.shared.detection(
+            "Slack poll udp=\(udpCount) consec=\(consecutiveOverThreshold) iopm=\(iopmActive) sustained=\(sustained) active=\(active)",
+            platform: .slack, signal: .networkUDP
+        )
+
+        if active {
+            peakUDPDuringActive = max(peakUDPDuringActive, udpCount)
+        }
+
+        let was = lastNetworkActive
+        lastNetworkActive = active
+        guard active != was else { return }
+
+        if active {
+            activeSince = Date()
+            let endpoints = Self.slackUDPEndpoints(limit: 10).joined(separator: ",")
+            let names = assertionNames.joined(separator: "|")
             DetectionLogger.shared.detection(
-                "Network UDP sockets=\(udpCount) active=\(active)",
-                platform: .slack, signal: .networkUDP, active: active
+                "Slack ACTIVE udp=\(udpCount) peak=\(peakUDPDuringActive) iopm=[\(names)] endpoints=[\(endpoints)]",
+                platform: .slack, signal: .networkUDP, active: true
             )
-            let signal = MeetingSignal(
-                platform: .slack,
-                isActive: active,
-                confidence: .high,
-                source: .networkUDP,
-                timestamp: Date()
+        } else {
+            let duration = activeSince.map { Date().timeIntervalSince($0) } ?? 0
+            let likelyFP = duration < Self.falsePositiveDurationCutoff
+            DetectionLogger.shared.detection(
+                "Slack INACTIVE duration=\(String(format: "%.1f", duration))s peak=\(peakUDPDuringActive) likelyFalsePositive=\(likelyFP)",
+                platform: .slack, signal: .networkUDP, active: false
             )
-            onSignal(signal)
+            activeSince = nil
+            peakUDPDuringActive = 0
         }
+
+        let signal = MeetingSignal(
+            platform: .slack,
+            isActive: active,
+            confidence: .high,
+            source: .networkUDP,
+            timestamp: Date()
+        )
+        onSignal(signal)
     }
 
+    // MARK: - lsof helpers
+
     static func countSlackUDPSockets() -> Int {
+        let output = runLsof()
+        let lines = output.components(separatedBy: "\n").filter { !$0.isEmpty }
+        return max(0, lines.count - 1)
+    }
+
+    /// Remote-address column from each UDP socket row, truncated to `limit`.
+    /// Diagnostic only — used in the active-edge log line.
+    static func slackUDPEndpoints(limit: Int) -> [String] {
+        let output = runLsof()
+        var endpoints: [String] = []
+        for (i, line) in output.components(separatedBy: "\n").enumerated() {
+            if i == 0 || line.isEmpty { continue } // skip header
+            let cols = line.split(separator: " ", omittingEmptySubsequences: true)
+            if let name = cols.last {
+                endpoints.append(String(name))
+                if endpoints.count >= limit { break }
+            }
+        }
+        return endpoints
+    }
+
+    private static func runLsof() -> String {
         let process = Process()
         process.executableURL = URL(fileURLWithPath: "/usr/sbin/lsof")
         process.arguments = ["-a", "-i", "UDP", "-n", "-P", "-c", "Slack"]
@@ -86,12 +156,44 @@ final class SlackDetector: MeetingDetector, WindowListConsumer, @unchecked Senda
             try process.run()
             process.waitUntilExit()
         } catch {
-            return 0
+            return ""
         }
         let data = pipe.fileHandleForReading.readDataToEndOfFile()
-        guard let output = String(data: data, encoding: .utf8) else { return 0 }
-        let lines = output.components(separatedBy: "\n").filter { !$0.isEmpty }
-        return max(0, lines.count - 1)
+        return String(data: data, encoding: .utf8) ?? ""
+    }
+
+    // MARK: - IOPM assertion check
+
+    /// Returns (anyHeld, assertionNames) for Slack-held idle-sleep assertions.
+    /// During huddles Slack typically holds PreventUserIdleDisplaySleep and/or
+    /// PreventUserIdleSystemSleep. Notification sounds / previews do not.
+    static func slackAssertions() -> (Bool, [String]) {
+        guard let pid = NSRunningApplication
+            .runningApplications(withBundleIdentifier: slackBundleID)
+            .first?.processIdentifier
+        else { return (false, []) }
+
+        var assertionsByProcess: Unmanaged<CFDictionary>?
+        IOPMCopyAssertionsByProcess(&assertionsByProcess)
+        guard let dict = assertionsByProcess?.takeRetainedValue()
+                as? [String: [[String: Any]]]
+        else { return (false, []) }
+
+        var names: [String] = []
+        for (_, assertions) in dict {
+            for assertion in assertions {
+                guard let assertPID = assertion["AssertPID"] as? Int32,
+                      assertPID == pid,
+                      let type = assertion["AssertType"] as? String
+                else { continue }
+                if type == "PreventUserIdleDisplaySleep" ||
+                   type == "PreventUserIdleSystemSleep" {
+                    let name = (assertion["AssertName"] as? String) ?? type
+                    names.append(name)
+                }
+            }
+        }
+        return (!names.isEmpty, names)
     }
 
     // MARK: - CGWindowList Detection


### PR DESCRIPTION
## Summary

- `SlackDetector` was firing on transient UDP socket bursts (Slack notification sounds, voice-message previews, ringtones), kicking the state machine into `recording(slack)` and producing cascades of "Stop recording failed: Element not found" automation errors in `~/Library/Logs/MacWhisperAuto/detection.jsonl`.
- Root cause from the log: Slack's idle UDP socket count is **2**, the previous threshold was `udpCount > 2`, so a single transient extra socket triggered detection. Bursts routinely lasted 20–30s — longer than the state machine's 5s `startDebounce`, so debounce did not save us.

## Changes (`Sources/Detection/SlackDetector.swift`)

- Raise `udpSocketThreshold` from `2` to `4` (fire only when `udpCount >= 5`).
- Add a sustained-poll counter: require **2 consecutive over-threshold polls** (~3–6s) before considering UDP active.
- **AND-gate with an IOPM assertion check**: emit `active=true` only when Slack also holds a `PreventUserIdleDisplaySleep` or `PreventUserIdleSystemSleep` assertion. Notification sounds / previews do not hold these assertions, so this single co-signal eliminates the entire false-positive class. Pattern lifted from `FaceTimeDetector.swift`.
- Either signal dropping flips `active=false` immediately — the existing 15s `stopGrace` timer in `MeetingStateMachine` handles release.
- **Diagnostic logging** so Phase 2 tuning is data-driven:
  - Per-poll debug line: `Slack poll udp=N consec=K iopm=B sustained=B active=B`.
  - Active-edge: peak UDP count seen, IOPM `AssertName`s, and truncated `lsof` remote endpoints.
  - Inactive-edge: duration and `likelyFalsePositive` flag (`duration < 60s`).

End-to-end delay from real huddle start to recording: **~5–8s → ~8–11s**. `CGWindowList` huddle-title path is unchanged. No state-machine, logger, or other detector changes.

## Test plan

- [ ] **Baseline**: launch app, leave Slack open and idle ~5 min. Confirm log shows `udp=2 consec=0 sustained=false` and **no** `idle -> detecting(slack)` transitions.
- [ ] **False-positive regression test**: DM yourself on Slack / trigger a Slack sound. Confirm `udp` spikes to 3 in the log, `consec` resets before reaching 2, and **no recording is started**.
- [ ] **Real huddle**: start a Slack huddle. Confirm:
  - `udp` reaches ≥ 5
  - `iopm=true` appears alongside
  - `sustained=true` after ~6s
  - `idle -> detecting(slack)` → `detecting -> recording(slack)` ~5s later
  - On hangup: prompt drop to `active=false`, recording stops after 15s grace
- [ ] **Review active-edge log** for the real huddle to capture peak UDP count + assertion name for future tuning.

## Follow-up (Phase 2, not in this PR)

After a week of richer logs:
- If real huddles reliably reach `udp >= 6`, raise threshold to `5`.
- If IOPM is **not** held on your macOS/Slack version, fall back to UDP-only with `sustainedPollsRequired = 3`.
- If IOPM alone is 100% reliable, consider dropping the sustained window entirely to claw back ~3s of latency.