### PR TITLE
Menu-bar start path + idempotent stop + detector heartbeats

### DIFF
--- a/Sources/Automation/MacWhisperController.swift
+++ b/Sources/Automation/MacWhisperController.swift
@@ -138,46 +138,88 @@ final class MacWhisperController: Sendable {
         return .success(element)
     }
 
-    /// Start recording - find "Record [Platform]" button and press it.
+    /// Start recording via MacWhisper's status-menu "Record Meeting" submenu.
+    /// FaceTime falls through to a window-based fallback because the menu has no FaceTime item.
     private func performStartRecording(platform: Platform) -> Result<Void, AXError> {
         switch createAppElement() {
         case .failure(let error):
             return .failure(error)
         case .success(let appElement):
-            if platform == .faceTime {
-                return performStartFaceTimeRecording(appElement: appElement)
+            if let menuTitle = platform.macWhisperMenuTitle {
+                return performStartRecordingViaMenu(
+                    appElement: appElement, menuTitle: menuTitle, platform: platform
+                )
             }
-
-            let buttonName = platform.macWhisperButtonName
-            DetectionLogger.shared.automation(
-                "Starting recording: looking for '\(buttonName)'", action: "startRecording"
-            )
-
-            let windows = AccessibilityHelper.arrayAttribute(appElement, kAXWindowsAttribute)
-            for window in windows {
-                if let button = AccessibilityHelper.findByDescription(
-                    window, description: buttonName
-                ) {
-                    DetectionLogger.shared.automation(
-                        "Found '\(buttonName)' - pressing", action: "startRecording"
-                    )
-                    let result = AccessibilityHelper.press(button)
-                    switch result {
-                    case .success:
-                        DetectionLogger.shared.automation(
-                            "Recording started for \(platform.displayName)",
-                            action: "startRecording"
-                        )
-                    case .failure(let error):
-                        DetectionLogger.shared.error(
-                            .automation, "Failed to press '\(buttonName)': \(error)"
-                        )
-                    }
-                    return result
-                }
-            }
-            return .failure(.elementNotFound(description: buttonName))
+            return performStartFaceTimeRecording(appElement: appElement)
         }
+    }
+
+    /// Navigate the status-menu extra → "Record Meeting" submenu → <platform> item.
+    private func performStartRecordingViaMenu(
+        appElement: AXUIElement, menuTitle: String, platform: Platform
+    ) -> Result<Void, AXError> {
+        guard let extras: AXUIElement =
+                AccessibilityHelper.attribute(appElement, kAXExtrasMenuBarAttribute) else {
+            return .failure(.elementNotFound(description: "MacWhisper menu extra"))
+        }
+        let items = AccessibilityHelper.arrayAttribute(extras, kAXChildrenAttribute)
+        guard let menuExtra = items.first else {
+            return .failure(.elementNotFound(description: "MacWhisper menu extra"))
+        }
+
+        DetectionLogger.shared.automation(
+            "Opening MacWhisper menu extra", action: "startRecording"
+        )
+        let openErr = AXUIElementPerformAction(menuExtra, kAXPressAction as CFString)
+        guard openErr == .success else {
+            return .failure(.actionFailed(
+                element: "AXMenuExtra", action: "AXPress", code: openErr.rawValue
+            ))
+        }
+        Thread.sleep(forTimeInterval: 0.3)
+
+        guard let recordMeeting = AccessibilityHelper.findMenuItemByTitle(
+            menuExtra, title: "Record Meeting"
+        ) else {
+            AXUIElementPerformAction(menuExtra, kAXCancelAction as CFString)
+            return .failure(.elementNotFound(description: "Record Meeting"))
+        }
+
+        DetectionLogger.shared.automation(
+            "Expanding Record Meeting submenu", action: "startRecording"
+        )
+        let expandErr = AXUIElementPerformAction(recordMeeting, kAXPressAction as CFString)
+        guard expandErr == .success else {
+            AXUIElementPerformAction(menuExtra, kAXCancelAction as CFString)
+            return .failure(.actionFailed(
+                element: "AXMenuItem:Record Meeting", action: "AXPress", code: expandErr.rawValue
+            ))
+        }
+        Thread.sleep(forTimeInterval: 0.3)
+
+        guard let platformItem = AccessibilityHelper.findMenuItemByTitle(
+            recordMeeting, title: menuTitle
+        ) else {
+            AXUIElementPerformAction(menuExtra, kAXCancelAction as CFString)
+            return .failure(.elementNotFound(description: menuTitle))
+        }
+
+        DetectionLogger.shared.automation(
+            "Pressing '\(menuTitle)' menu item", action: "startRecording"
+        )
+        let result = AccessibilityHelper.press(platformItem)
+        switch result {
+        case .success:
+            DetectionLogger.shared.automation(
+                "Recording started for \(platform.displayName)", action: "startRecording"
+            )
+        case .failure(let error):
+            AXUIElementPerformAction(menuExtra, kAXCancelAction as CFString)
+            DetectionLogger.shared.error(
+                .automation, "Failed to press '\(menuTitle)': \(error)"
+            )
+        }
+        return result
     }
 
     /// Manual recording by raw button name.
@@ -285,7 +327,12 @@ final class MacWhisperController: Sendable {
                 }
             }
 
-            return .failure(.elementNotFound(description: "Finish Recording dialog or active recording"))
+            // No dialog and no active recording row — MacWhisper isn't recording.
+            // Treat stop as idempotent so the app's state still clears to idle.
+            DetectionLogger.shared.automation(
+                "No active recording found — treating stop as no-op", action: "stopRecording"
+            )
+            return .success(())
         }
     }
 

--- a/Sources/Core/Platform.swift
+++ b/Sources/Core/Platform.swift
@@ -3,14 +3,16 @@ import Foundation
 enum Platform: String, CaseIterable, Sendable {
     case teams, zoom, slack, faceTime, chime, browser
 
-    var macWhisperButtonName: String {
+    /// Title of the platform's item under MacWhisper's status-menu "Record Meeting" submenu.
+    /// `nil` means the platform is not exposed in the menu and must use a window-based fallback.
+    var macWhisperMenuTitle: String? {
         switch self {
-        case .teams: "Record Teams"
-        case .zoom: "Record Zoom"
-        case .slack: "Record Slack"
-        case .faceTime: "Record FaceTime"
-        case .chime: "Record Chime"
-        case .browser: "Record Comet"
+        case .teams: "Teams"
+        case .zoom: "Zoom"
+        case .slack: "Slack"
+        case .chime: "Chime"
+        case .browser: "Comet"
+        case .faceTime: nil
         }
     }
 

--- a/Sources/Detection/ChimeDetector.swift
+++ b/Sources/Detection/ChimeDetector.swift
@@ -59,19 +59,21 @@ final class ChimeDetector: MeetingDetector, WindowListConsumer, @unchecked Senda
         let lastActive = _lastNetworkActive.withLock { old -> Bool in
             let was = old; old = active; return was
         }
-        if active != lastActive {
+        let changed = active != lastActive
+        if changed {
             DetectionLogger.shared.detection(
                 "Network UDP sockets=\(udpCount) active=\(active)",
                 platform: .chime, signal: .networkUDP, active: active
             )
-            let signal = MeetingSignal(
+        }
+        if changed || active {
+            onSignal(MeetingSignal(
                 platform: .chime,
                 isActive: active,
                 confidence: .high,
                 source: .networkUDP,
                 timestamp: Date()
-            )
-            onSignal(signal)
+            ))
         }
     }
 
@@ -111,19 +113,21 @@ final class ChimeDetector: MeetingDetector, WindowListConsumer, @unchecked Senda
             return was
         }
 
-        if active != lastActive {
+        let changed = active != lastActive
+        if changed {
             DetectionLogger.shared.detection(
                 "Chime meeting window \(active ? "found" : "gone")",
                 platform: .chime, signal: .cgWindowList, active: active
             )
-            let signal = MeetingSignal(
+        }
+        if changed || active {
+            onSignal(MeetingSignal(
                 platform: .chime,
                 isActive: active,
                 confidence: .high,
                 source: .cgWindowList,
                 timestamp: Date()
-            )
-            onSignal(signal)
+            ))
         }
     }
 }

--- a/Sources/Detection/FaceTimeDetector.swift
+++ b/Sources/Detection/FaceTimeDetector.swift
@@ -141,19 +141,21 @@ final class FaceTimeDetector: MeetingDetector, WindowListConsumer, @unchecked Se
             return was
         }
 
-        if active != lastActive {
+        let changed = active != lastActive
+        if changed {
             DetectionLogger.shared.detection(
                 "FaceTime call \(active ? "detected" : "ended") (assertion=\(assertionActive), window=\(windowVisible))",
                 platform: .faceTime, signal: .iopmAssertion, active: active
             )
-            let signal = MeetingSignal(
+        }
+        if changed || active {
+            onSignal(MeetingSignal(
                 platform: .faceTime,
                 isActive: active,
                 confidence: .high,
                 source: .iopmAssertion,
                 timestamp: Date()
-            )
-            onSignal(signal)
+            ))
         }
     }
 }

--- a/Sources/Detection/SlackDetector.swift
+++ b/Sources/Detection/SlackDetector.swift
@@ -78,7 +78,7 @@ final class SlackDetector: MeetingDetector, WindowListConsumer, @unchecked Senda
         let sustained = consecutiveOverThreshold >= Self.sustainedPollsRequired
         let active = sustained && iopmActive
 
-        // Per-poll diagnostic (debug level) - so Phase 2 tuning is data-driven.
+        // Per-poll diagnostic - so future tuning is data-driven.
         DetectionLogger.shared.detection(
             "Slack poll udp=\(udpCount) consec=\(consecutiveOverThreshold) iopm=\(iopmActive) sustained=\(sustained) active=\(active)",
             platform: .slack, signal: .networkUDP
@@ -90,35 +90,40 @@ final class SlackDetector: MeetingDetector, WindowListConsumer, @unchecked Senda
 
         let was = lastNetworkActive
         lastNetworkActive = active
-        guard active != was else { return }
+        let changed = active != was
 
-        if active {
-            activeSince = Date()
-            let endpoints = Self.slackUDPEndpoints(limit: 10).joined(separator: ",")
-            let names = assertionNames.joined(separator: "|")
-            DetectionLogger.shared.detection(
-                "Slack ACTIVE udp=\(udpCount) peak=\(peakUDPDuringActive) iopm=[\(names)] endpoints=[\(endpoints)]",
-                platform: .slack, signal: .networkUDP, active: true
-            )
-        } else {
-            let duration = activeSince.map { Date().timeIntervalSince($0) } ?? 0
-            let likelyFP = duration < Self.falsePositiveDurationCutoff
-            DetectionLogger.shared.detection(
-                "Slack INACTIVE duration=\(String(format: "%.1f", duration))s peak=\(peakUDPDuringActive) likelyFalsePositive=\(likelyFP)",
-                platform: .slack, signal: .networkUDP, active: false
-            )
-            activeSince = nil
-            peakUDPDuringActive = 0
+        // Edge logs only on transitions (active/inactive summaries)
+        if changed {
+            if active {
+                activeSince = Date()
+                let endpoints = Self.slackUDPEndpoints(limit: 10).joined(separator: ",")
+                let names = assertionNames.joined(separator: "|")
+                DetectionLogger.shared.detection(
+                    "Slack ACTIVE udp=\(udpCount) peak=\(peakUDPDuringActive) iopm=[\(names)] endpoints=[\(endpoints)]",
+                    platform: .slack, signal: .networkUDP, active: true
+                )
+            } else {
+                let duration = activeSince.map { Date().timeIntervalSince($0) } ?? 0
+                let likelyFP = duration < Self.falsePositiveDurationCutoff
+                DetectionLogger.shared.detection(
+                    "Slack INACTIVE duration=\(String(format: "%.1f", duration))s peak=\(peakUDPDuringActive) likelyFalsePositive=\(likelyFP)",
+                    platform: .slack, signal: .networkUDP, active: false
+                )
+                activeSince = nil
+                peakUDPDuringActive = 0
+            }
         }
 
-        let signal = MeetingSignal(
-            platform: .slack,
-            isActive: active,
-            confidence: .high,
-            source: .networkUDP,
-            timestamp: Date()
-        )
-        onSignal(signal)
+        // Emit on transition OR while active (heartbeat — recovers stuck idle state)
+        if changed || active {
+            onSignal(MeetingSignal(
+                platform: .slack,
+                isActive: active,
+                confidence: .high,
+                source: .networkUDP,
+                timestamp: Date()
+            ))
+        }
     }
 
     // MARK: - lsof helpers
@@ -212,19 +217,21 @@ final class SlackDetector: MeetingDetector, WindowListConsumer, @unchecked Senda
             return was
         }
 
-        if active != lastActive {
+        let changed = active != lastActive
+        if changed {
             DetectionLogger.shared.detection(
                 "Slack huddle window \(active ? "found" : "gone")",
                 platform: .slack, signal: .cgWindowList, active: active
             )
-            let signal = MeetingSignal(
+        }
+        if changed || active {
+            onSignal(MeetingSignal(
                 platform: .slack,
                 isActive: active,
                 confidence: .high,
                 source: .cgWindowList,
                 timestamp: Date()
-            )
-            onSignal(signal)
+            ))
         }
     }
 }

--- a/Sources/Detection/SlackDetector.swift
+++ b/Sources/Detection/SlackDetector.swift
@@ -1,20 +1,32 @@
+import AppKit
 import Foundation
+import IOKit.pwr_mgt
 import os
 
-/// Detects Slack huddles via two complementary signals:
-/// 1. CGWindowList: "huddle" in window titles (needs Screen Recording)
-/// 2. Network UDP: Count of UDP sockets for Slack process (no permissions needed)
+/// Detects Slack huddles via two complementary paths:
+/// 1. CGWindowList: "huddle" in window titles (needs Screen Recording permission).
+/// 2. Network UDP + IOPM assertion (AND-gated): Slack holds many UDP sockets AND
+///    a PreventUserIdleDisplaySleep/SystemSleep assertion during huddles. The UDP
+///    count must stay above threshold for several consecutive polls to filter
+///    transient bursts from notification sounds, voice-message previews, etc.
 final class SlackDetector: MeetingDetector, WindowListConsumer, @unchecked Sendable {
     private let onSignal: @Sendable (MeetingSignal) -> Void
     private let _isEnabled = OSAllocatedUnfairLock(initialState: false)
     private let _lastActive = OSAllocatedUnfairLock(initialState: false)
 
-    // Network UDP state
-    private let _lastNetworkActive = OSAllocatedUnfairLock(initialState: false)
+    // Poll-queue-confined state (only touched from pollQueue)
     private var pollTimer: DispatchSourceTimer?
     private let pollQueue = DispatchQueue(label: "com.macwhisperauto.slack.poll")
+    private var consecutiveOverThreshold = 0
+    private var lastNetworkActive = false
+    private var peakUDPDuringActive = 0
+    private var activeSince: Date?
+
     private static let pollInterval: TimeInterval = 3.0
-    private static let udpSocketThreshold = 2
+    private static let udpSocketThreshold = 4          // fire when count > 4 (i.e. >= 5)
+    private static let sustainedPollsRequired = 2      // ~3-6s sustained over-threshold
+    private static let slackBundleID = "com.tinyspeck.slackmacgap"
+    private static let falsePositiveDurationCutoff: TimeInterval = 60.0
 
     var isEnabled: Bool { _isEnabled.withLock { $0 } }
 
@@ -28,7 +40,7 @@ final class SlackDetector: MeetingDetector, WindowListConsumer, @unchecked Senda
 
     func start() {
         _isEnabled.withLock { $0 = true }
-        startNetworkPolling()
+        startPolling()
         DetectionLogger.shared.detection("SlackDetector started", platform: .slack)
     }
 
@@ -39,43 +51,101 @@ final class SlackDetector: MeetingDetector, WindowListConsumer, @unchecked Senda
         DetectionLogger.shared.detection("SlackDetector stopped", platform: .slack)
     }
 
-    // MARK: - Network UDP Detection
+    // MARK: - Combined UDP + IOPM polling
 
-    private func startNetworkPolling() {
+    private func startPolling() {
         let timer = DispatchSource.makeTimerSource(queue: pollQueue)
         timer.schedule(deadline: .now(), repeating: Self.pollInterval, leeway: .milliseconds(500))
         timer.setEventHandler { [weak self] in
-            self?.pollNetworkConnections()
+            self?.pollOnce()
         }
         timer.resume()
         pollTimer = timer
     }
 
-    private func pollNetworkConnections() {
+    private func pollOnce() {
         guard isEnabled else { return }
-        let udpCount = Self.countSlackUDPSockets()
-        let active = udpCount > Self.udpSocketThreshold
 
-        let lastActive = _lastNetworkActive.withLock { old -> Bool in
-            let was = old; old = active; return was
+        let udpCount = Self.countSlackUDPSockets()
+        let overThreshold = udpCount > Self.udpSocketThreshold
+        let (iopmActive, assertionNames) = Self.slackAssertions()
+
+        if overThreshold {
+            consecutiveOverThreshold += 1
+        } else {
+            consecutiveOverThreshold = 0
         }
-        if active != lastActive {
+        let sustained = consecutiveOverThreshold >= Self.sustainedPollsRequired
+        let active = sustained && iopmActive
+
+        // Per-poll diagnostic (debug level) - so Phase 2 tuning is data-driven.
+        DetectionLogger.shared.detection(
+            "Slack poll udp=\(udpCount) consec=\(consecutiveOverThreshold) iopm=\(iopmActive) sustained=\(sustained) active=\(active)",
+            platform: .slack, signal: .networkUDP
+        )
+
+        if active {
+            peakUDPDuringActive = max(peakUDPDuringActive, udpCount)
+        }
+
+        let was = lastNetworkActive
+        lastNetworkActive = active
+        guard active != was else { return }
+
+        if active {
+            activeSince = Date()
+            let endpoints = Self.slackUDPEndpoints(limit: 10).joined(separator: ",")
+            let names = assertionNames.joined(separator: "|")
             DetectionLogger.shared.detection(
-                "Network UDP sockets=\(udpCount) active=\(active)",
-                platform: .slack, signal: .networkUDP, active: active
+                "Slack ACTIVE udp=\(udpCount) peak=\(peakUDPDuringActive) iopm=[\(names)] endpoints=[\(endpoints)]",
+                platform: .slack, signal: .networkUDP, active: true
             )
-            let signal = MeetingSignal(
-                platform: .slack,
-                isActive: active,
-                confidence: .high,
-                source: .networkUDP,
-                timestamp: Date()
+        } else {
+            let duration = activeSince.map { Date().timeIntervalSince($0) } ?? 0
+            let likelyFP = duration < Self.falsePositiveDurationCutoff
+            DetectionLogger.shared.detection(
+                "Slack INACTIVE duration=\(String(format: "%.1f", duration))s peak=\(peakUDPDuringActive) likelyFalsePositive=\(likelyFP)",
+                platform: .slack, signal: .networkUDP, active: false
             )
-            onSignal(signal)
+            activeSince = nil
+            peakUDPDuringActive = 0
         }
+
+        let signal = MeetingSignal(
+            platform: .slack,
+            isActive: active,
+            confidence: .high,
+            source: .networkUDP,
+            timestamp: Date()
+        )
+        onSignal(signal)
     }
 
+    // MARK: - lsof helpers
+
     static func countSlackUDPSockets() -> Int {
+        let output = runLsof()
+        let lines = output.components(separatedBy: "\n").filter { !$0.isEmpty }
+        return max(0, lines.count - 1)
+    }
+
+    /// Remote-address column from each UDP socket row, truncated to `limit`.
+    /// Diagnostic only — used in the active-edge log line.
+    static func slackUDPEndpoints(limit: Int) -> [String] {
+        let output = runLsof()
+        var endpoints: [String] = []
+        for (i, line) in output.components(separatedBy: "\n").enumerated() {
+            if i == 0 || line.isEmpty { continue } // skip header
+            let cols = line.split(separator: " ", omittingEmptySubsequences: true)
+            if let name = cols.last {
+                endpoints.append(String(name))
+                if endpoints.count >= limit { break }
+            }
+        }
+        return endpoints
+    }
+
+    private static func runLsof() -> String {
         let process = Process()
         process.executableURL = URL(fileURLWithPath: "/usr/sbin/lsof")
         process.arguments = ["-a", "-i", "UDP", "-n", "-P", "-c", "Slack"]
@@ -86,12 +156,44 @@ final class SlackDetector: MeetingDetector, WindowListConsumer, @unchecked Senda
             try process.run()
             process.waitUntilExit()
         } catch {
-            return 0
+            return ""
         }
         let data = pipe.fileHandleForReading.readDataToEndOfFile()
-        guard let output = String(data: data, encoding: .utf8) else { return 0 }
-        let lines = output.components(separatedBy: "\n").filter { !$0.isEmpty }
-        return max(0, lines.count - 1)
+        return String(data: data, encoding: .utf8) ?? ""
+    }
+
+    // MARK: - IOPM assertion check
+
+    /// Returns (anyHeld, assertionNames) for Slack-held idle-sleep assertions.
+    /// During huddles Slack typically holds PreventUserIdleDisplaySleep and/or
+    /// PreventUserIdleSystemSleep. Notification sounds / previews do not.
+    static func slackAssertions() -> (Bool, [String]) {
+        guard let pid = NSRunningApplication
+            .runningApplications(withBundleIdentifier: slackBundleID)
+            .first?.processIdentifier
+        else { return (false, []) }
+
+        var assertionsByProcess: Unmanaged<CFDictionary>?
+        IOPMCopyAssertionsByProcess(&assertionsByProcess)
+        guard let dict = assertionsByProcess?.takeRetainedValue()
+                as? [String: [[String: Any]]]
+        else { return (false, []) }
+
+        var names: [String] = []
+        for (_, assertions) in dict {
+            for assertion in assertions {
+                guard let assertPID = assertion["AssertPID"] as? Int32,
+                      assertPID == pid,
+                      let type = assertion["AssertType"] as? String
+                else { continue }
+                if type == "PreventUserIdleDisplaySleep" ||
+                   type == "PreventUserIdleSystemSleep" {
+                    let name = (assertion["AssertName"] as? String) ?? type
+                    names.append(name)
+                }
+            }
+        }
+        return (!names.isEmpty, names)
     }
 
     // MARK: - CGWindowList Detection

--- a/Sources/Detection/TeamsDetector.swift
+++ b/Sources/Detection/TeamsDetector.swift
@@ -228,12 +228,16 @@ final class TeamsDetector: MeetingDetector, WindowListConsumer, @unchecked Senda
         let lastActive = _lastIOPMActive.withLock { old -> Bool in
             let was = old; old = active; return was
         }
-        // Only log and emit on state change to avoid flooding
-        if active != lastActive {
+        let changed = active != lastActive
+        // Log only on transitions to avoid flooding; emit on transition OR while
+        // active (heartbeat — lets the state machine recover if it got stuck idle).
+        if changed {
             DetectionLogger.shared.detection(
                 "IOPM assertion active=\(active)",
                 platform: .teams, signal: .iopmAssertion, active: active
             )
+        }
+        if changed || active {
             emitSignal(active: active, source: .iopmAssertion, confidence: .high)
         }
     }
@@ -265,11 +269,14 @@ final class TeamsDetector: MeetingDetector, WindowListConsumer, @unchecked Senda
         let lastActive = _lastNetworkActive.withLock { old -> Bool in
             let was = old; old = active; return was
         }
-        if active != lastActive {
+        let changed = active != lastActive
+        if changed {
             DetectionLogger.shared.detection(
                 "Network UDP sockets=\(udpCount) active=\(active)",
                 platform: .teams, signal: .networkUDP, active: active
             )
+        }
+        if changed || active {
             emitSignal(active: active, source: .networkUDP, confidence: .high)
         }
     }
@@ -328,13 +335,15 @@ final class TeamsDetector: MeetingDetector, WindowListConsumer, @unchecked Senda
             old = active
             return was
         }
-
-        // Only emit on state change to avoid flooding the state machine
-        if active != lastActive {
+        let changed = active != lastActive
+        if changed {
             DetectionLogger.shared.detection(
                 "Teams meeting window \(active ? "found" : "gone")",
                 platform: .teams, signal: .cgWindowList, active: active
             )
+        }
+        // Emit on transition OR while active (heartbeat — recovers stuck idle state)
+        if changed || active {
             emitSignal(active: active, source: .cgWindowList, confidence: .high)
         }
     }

--- a/Sources/Detection/ZoomDetector.swift
+++ b/Sources/Detection/ZoomDetector.swift
@@ -61,19 +61,22 @@ final class ZoomDetector: MeetingDetector, WindowListConsumer, @unchecked Sendab
         let lastActive = _lastNetworkActive.withLock { old -> Bool in
             let was = old; old = active; return was
         }
-        if active != lastActive {
+        let changed = active != lastActive
+        if changed {
             DetectionLogger.shared.detection(
                 "Network UDP sockets=\(udpCount) active=\(active)",
                 platform: .zoom, signal: .networkUDP, active: active
             )
-            let signal = MeetingSignal(
+        }
+        // Emit on transition OR while active (heartbeat — recovers stuck idle state)
+        if changed || active {
+            onSignal(MeetingSignal(
                 platform: .zoom,
                 isActive: active,
                 confidence: .high,
                 source: .networkUDP,
                 timestamp: Date()
-            )
-            onSignal(signal)
+            ))
         }
     }
 
@@ -115,19 +118,21 @@ final class ZoomDetector: MeetingDetector, WindowListConsumer, @unchecked Sendab
             return was
         }
 
-        if active != lastActive {
+        let changed = active != lastActive
+        if changed {
             DetectionLogger.shared.detection(
                 "Zoom meeting window \(active ? "found" : "gone")",
                 platform: .zoom, signal: .cgWindowList, active: active
             )
-            let signal = MeetingSignal(
+        }
+        if changed || active {
+            onSignal(MeetingSignal(
                 platform: .zoom,
                 isActive: active,
                 confidence: .high,
                 source: .cgWindowList,
                 timestamp: Date()
-            )
-            onSignal(signal)
+            ))
         }
     }
 }


### PR DESCRIPTION
## Summary

Three related changes to make MacWhisperAuto more reliable in real meetings:

- **Use MacWhisper's menu-bar `Record Meeting` submenu** to start recordings instead of finding `Record <Platform>` buttons in MacWhisper's windows. The window buttons only render when MacWhisper's main window is laid out, so detection-triggered starts could miss. The status-menu submenu (`Comet` / `Teams` / `Slack` / `Chime` / `Zoom`) is always addressable as `AXMenuItem` titles via `kAXExtrasMenuBarAttribute` regardless of window state. `Platform.macWhisperMenuTitle` carries the per-platform title; new `performStartRecordingViaMenu` walks AXMenuExtra → press to open → `Record Meeting` press to expand lazy submenu → leaf-item press. FaceTime keeps the existing window-based fallback because the menu has no FaceTime item.
- **Make `performStopRecording` idempotent.** Previously, clicking Stop when MacWhisper wasn't actually recording returned `.elementNotFound` and the app's state did not clear, leaving a stuck `.recording` state. Now it returns success when there is no finish-recording dialog and no active recording row, so the app transitions to `.idle` cleanly.
- **Emit detector signals as heartbeats while active.** Polled detectors only emitted on `active != lastActive` transitions, so if the state machine dropped to idle while a detector's cached state was still `active=true` (e.g. transient CoreAudio blip during the 5s debounce, grace timer fired between polls), no detector ever re-emitted and the app got permanently stuck idle. Live-confirmed in a Teams call: 5 UDP sockets, IOPM `Microsoft Teams Call in progress` assertion held, meeting window visible — and the app still showed idle. Each poller now emits on transition OR while active. Applied to Teams, Zoom, Slack, Chime, FaceTime. Logging stays gated on transitions so the activity log isn't flooded.

> Note: this branch includes #39's commit (`Suppress Slack huddle false positives via IOPM + sustained UDP gate`). When #39 lands, this PR will deduplicate on rebase. The heartbeat change in `SlackDetector` preserves #39's stricter `sustained && iopmActive` gate and only replaces the change-only emission with the heartbeat pattern.

## Test plan

- [ ] `swift build` clean.
- [ ] Auto-start during a Teams call: detection fires within ~5–10s, recording starts via menu, activity log shows `Opening MacWhisper menu extra` → `Expanding Record Meeting submenu` → `Pressing 'Teams' menu item` → `Recording started for Microsoft Teams`.
- [ ] Repeat for Zoom / Slack / Chime / Comet (browser).
- [ ] FaceTime recording still starts via `Record All System Audio` window-button fallback.
- [ ] Manual record buttons in the status menu (`Chrome`, `System`) still find their window buttons.
- [ ] Stop Recording while MacWhisper is **not** actually recording — app's state clears to idle immediately, no error in activity log.
- [ ] Stop Recording during a real recording — `Finish Recording` dialog flow unchanged.
- [ ] Recovery: trigger an artificial state-machine reset (e.g. brief CoreAudio mute) mid-call, confirm the detector re-emits within 3s and recording resumes.