### PR TITLE
Skip Homebrew tap update when token missing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -75,6 +75,11 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN }}
         run: |
+          if [ -z "$GH_TOKEN" ]; then
+            echo "HOMEBREW_TAP_TOKEN not configured; skipping Homebrew tap update."
+            echo "To enable, create a PAT with 'workflow' scope for chrisns/homebrew-macwhisperauto and set it as the HOMEBREW_TAP_TOKEN repo secret."
+            exit 0
+          fi
           gh workflow run update.yml \
             --repo chrisns/homebrew-macwhisperauto \
             --field version="${{ needs.version.outputs.semver }}" \


### PR DESCRIPTION
## Summary
- The cross-repo `gh workflow run` in the Release job fails when `HOMEBREW_TAP_TOKEN` is unset (it is currently unset on this repo), turning every push-to-main release red even though the GitHub Release itself was created successfully.
- Guard the step so it logs a clear message and exits 0 when the secret is missing. Existing behaviour is preserved once the PAT is configured.

## Test plan
- [ ] After merge, the Release run on main completes successfully.
- [ ] Log shows the skip message until `HOMEBREW_TAP_TOKEN` is added.