### PR TITLE
Drive recording status from MacWhisper reality, not optimism

### DIFF
--- a/Sources/App/AppDelegate.swift
+++ b/Sources/App/AppDelegate.swift
@@ -448,72 +448,6 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         }
     }
 
-    // MARK: - Recording Observation (Reality Poll)
-
-    /// Start polling MacWhisper for its actual recording state. The poll
-    /// drives `appState.macWhisperObservedRecording`, which is what the UI
-    /// surfaces as "Recording" (vs "Starting..."). Safe to call repeatedly.
-    private func startRecordingObservation() {
-        if recordingObservationTimer != nil { return }
-        let timer = DispatchSource.makeTimerSource(queue: .main)
-        timer.schedule(deadline: .now() + 0.5, repeating: 2.0, leeway: .milliseconds(500))
-        timer.setEventHandler { [weak self] in
-            self?.pollRecordingObservation()
-        }
-        timer.resume()
-        recordingObservationTimer = timer
-    }
-
-    private func stopRecordingObservation() {
-        recordingObservationTimer?.cancel()
-        recordingObservationTimer = nil
-        appState.macWhisperObservedRecording = false
-        appState.macWhisperMenuItemMissing = nil
-    }
-
-    private func pollRecordingObservation() {
-        // Self-stop once intent leaves .recording and there's nothing left
-        // to confirm. Covers paths that transition to .idle/.error without
-        // going through handleStopRecording (e.g. clearError, sleep reset).
-        if case .recording = appState.meetingState {
-            // continue polling
-        } else if !appState.macWhisperObservedRecording {
-            stopRecordingObservation()
-            return
-        }
-
-        let stateRef = appState
-        macWhisperController.checkRecordingStatus { observed in
-            Task { @MainActor in
-                let previous = stateRef.macWhisperObservedRecording
-                if previous == observed { return }
-                stateRef.macWhisperObservedRecording = observed
-                let platform = stateRef.activePlatform
-                if observed {
-                    // false → true: MacWhisper is actually recording now.
-                    if case .recording = stateRef.meetingState {
-                        stateRef.addActivity(
-                            "Recording confirmed" +
-                                (platform.map { " for \($0.displayName)" } ?? ""),
-                            platform: platform
-                        )
-                    }
-                } else {
-                    // true → false: MacWhisper stopped recording. If intent
-                    // is still .recording, that means MacWhisper was stopped
-                    // externally (user pressed Finish, or MacWhisper crashed).
-                    if case .recording = stateRef.meetingState {
-                        stateRef.addActivity(
-                            "Recording stopped externally", platform: platform
-                        )
-                        stateRef.updateState(.idle)
-                        self.stopRecordingObservation()
-                    }
-                }
-            }
-        }
-    }
-
     private func handleStopRecording() {
         DetectionLogger.shared.automation("Side effect: stop recording", action: "stopRecording")
 
@@ -630,6 +564,74 @@ extension AppDelegate {
                 }
             default:
                 break
+            }
+        }
+    }
+}
+
+// MARK: - Recording Observation (Reality Poll)
+
+extension AppDelegate {
+    /// Start polling MacWhisper for its actual recording state. The poll
+    /// drives `appState.macWhisperObservedRecording`, which is what the UI
+    /// surfaces as "Recording" (vs "Starting..."). Safe to call repeatedly.
+    func startRecordingObservation() {
+        if recordingObservationTimer != nil { return }
+        let timer = DispatchSource.makeTimerSource(queue: .main)
+        timer.schedule(deadline: .now() + 0.5, repeating: 2.0, leeway: .milliseconds(500))
+        timer.setEventHandler { [weak self] in
+            self?.pollRecordingObservation()
+        }
+        timer.resume()
+        recordingObservationTimer = timer
+    }
+
+    func stopRecordingObservation() {
+        recordingObservationTimer?.cancel()
+        recordingObservationTimer = nil
+        appState.macWhisperObservedRecording = false
+        appState.macWhisperMenuItemMissing = nil
+    }
+
+    private func pollRecordingObservation() {
+        // Self-stop once intent leaves .recording and there's nothing left
+        // to confirm. Covers paths that transition to .idle/.error without
+        // going through handleStopRecording (e.g. clearError, sleep reset).
+        if case .recording = appState.meetingState {
+            // continue polling
+        } else if !appState.macWhisperObservedRecording {
+            stopRecordingObservation()
+            return
+        }
+
+        let stateRef = appState
+        macWhisperController.checkRecordingStatus { observed in
+            Task { @MainActor in
+                let previous = stateRef.macWhisperObservedRecording
+                if previous == observed { return }
+                stateRef.macWhisperObservedRecording = observed
+                let platform = stateRef.activePlatform
+                if observed {
+                    // false → true: MacWhisper is actually recording now.
+                    if case .recording = stateRef.meetingState {
+                        stateRef.addActivity(
+                            "Recording confirmed" +
+                                (platform.map { " for \($0.displayName)" } ?? ""),
+                            platform: platform
+                        )
+                    }
+                } else {
+                    // true → false: MacWhisper stopped recording. If intent
+                    // is still .recording, that means MacWhisper was stopped
+                    // externally (user pressed Finish, or MacWhisper crashed).
+                    if case .recording = stateRef.meetingState {
+                        stateRef.addActivity(
+                            "Recording stopped externally", platform: platform
+                        )
+                        stateRef.updateState(.idle)
+                        self.stopRecordingObservation()
+                    }
+                }
             }
         }
     }

--- a/Sources/App/AppDelegate.swift
+++ b/Sources/App/AppDelegate.swift
@@ -14,6 +14,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     private var webSocketServer: WebSocketServer?
     private var extensionMessageHandler: ExtensionMessageHandler?
     private var startRecordingRetryCount = 0
+    private var recordingObservationTimer: DispatchSourceTimer?
 
     func applicationDidFinishLaunching(_ notification: Notification) {
         DetectionLogger.shared.lifecycle("Application launched")
@@ -170,6 +171,8 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         DetectionLogger.shared.lifecycle("Application terminating")
         permissionCheckTimer?.cancel()
         permissionCheckTimer = nil
+        recordingObservationTimer?.cancel()
+        recordingObservationTimer = nil
         webSocketServer?.stop()
         coordinator?.stop()
         appMonitor?.stop()
@@ -287,21 +290,8 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         }
 
         startRecordingRetryCount = 0
-
-        let controller = macWhisperController
-        let coordRef = coordinator
-        let stateRef = appState
-
-        controller.launchIfNeeded { launched in
-            Task { @MainActor in
-                guard launched else {
-                    coordRef?.reportError(.macWhisperNotRunning)
-                    stateRef.addActivity("Failed to launch MacWhisper", platform: platform)
-                    return
-                }
-                self.attemptStartRecording(platform: platform)
-            }
-        }
+        startRecordingObservation()
+        attemptStartRecording(platform: platform)
     }
 
     /// Backoff schedule for transient "element not found" retries.
@@ -316,65 +306,101 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     }
 
     private func attemptStartRecording(platform: Platform) {
-        // If the meeting ended during retries, abandon silently
+        // If the meeting ended (or we transitioned to error/idle for any
+        // other reason) during retries, abandon silently.
         guard case .recording = appState.meetingState else {
             startRecordingRetryCount = 0
             return
         }
 
         let controller = macWhisperController
-        let coordRef = coordinator
         let stateRef = appState
 
-        controller.startRecording(for: platform) { result in
+        // Each attempt re-launches MacWhisper if needed, so a quit/crash
+        // during retries auto-recovers without leaving us stuck in error.
+        controller.launchIfNeeded { launchResult in
             Task { @MainActor in
-                switch result {
-                case .success:
+                guard case .recording = stateRef.meetingState else {
                     self.startRecordingRetryCount = 0
-                    stateRef.addActivity(
-                        "Recording started for \(platform.displayName)", platform: platform
-                    )
+                    return
+                }
+                switch launchResult {
                 case .failure(let error):
-                    if case .elementNotFound = error {
-                        // Retry indefinitely while the meeting is still active.
-                        // MacWhisper's menu extra is often briefly unavailable
-                        // (app launching, menu loading, AX cache cold) and
-                        // surfacing a hard error here just leaves recording stuck.
-                        self.startRecordingRetryCount += 1
-                        let attempt = self.startRecordingRetryCount
-                        let delay = Self.startRecordingRetryDelay(attempt: attempt)
-                        DetectionLogger.shared.automation(
-                            "Button not found, retrying in \(delay)s (attempt \(attempt))...",
-                            action: "startRecording"
-                        )
-                        // Log activity once at start, then every 10 attempts to avoid spam
-                        if attempt == 1 || attempt % 10 == 0 {
-                            stateRef.addActivity(
-                                "Button not found, retrying in background (attempt \(attempt))..."
-                            )
-                        }
-                        DispatchQueue.main.asyncAfter(deadline: .now() + delay) { [weak self] in
-                            self?.attemptStartRecording(platform: platform)
-                        }
-                    } else {
-                        self.startRecordingRetryCount = 0
-                        DetectionLogger.shared.error(.automation, "Start recording failed: \(error)")
-                        stateRef.addActivity("Recording failed: \(error)", platform: platform)
-                        switch error {
-                        case .macWhisperNotRunning:
-                            coordRef?.reportError(.macWhisperNotRunning)
-                        case .elementNotFound(let desc):
-                            coordRef?.reportError(.axElementNotFound(desc))
-                        case .timeout:
-                            coordRef?.reportError(.macWhisperUnresponsive)
-                        case .actionFailed:
-                            coordRef?.reportError(.macWhisperUnresponsive)
-                        case .noPermission:
-                            coordRef?.reportError(.permissionDenied(.accessibility))
+                    self.handleStartRecordingFailure(error, platform: platform)
+                case .success:
+                    controller.startRecording(for: platform) { result in
+                        Task { @MainActor in
+                            self.handleStartRecordingResult(result, platform: platform)
                         }
                     }
                 }
             }
+        }
+    }
+
+    private func handleStartRecordingResult(
+        _ result: Result<Void, AXError>, platform: Platform
+    ) {
+        switch result {
+        case .success:
+            startRecordingRetryCount = 0
+            appState.macWhisperMenuItemMissing = nil
+            // Don't log "Recording started" here — wait until the poll
+            // confirms MacWhisper actually has an active recording row.
+            // Log only that we successfully issued the start command.
+            DetectionLogger.shared.automation(
+                "Start command issued for \(platform.displayName)", action: "startRecording"
+            )
+        case .failure(let error):
+            handleStartRecordingFailure(error, platform: platform)
+        }
+    }
+
+    /// Decides whether a start-recording failure is transient (retry with
+    /// backoff) or permanent (report error and stop).
+    private func handleStartRecordingFailure(_ error: AXError, platform: Platform) {
+        switch error {
+        case .macWhisperNotInstalled:
+            startRecordingRetryCount = 0
+            DetectionLogger.shared.error(.automation, "MacWhisper not installed")
+            appState.addActivity("MacWhisper is not installed", platform: platform)
+            coordinator?.reportError(.macWhisperNotInstalled)
+        case .noPermission:
+            startRecordingRetryCount = 0
+            DetectionLogger.shared.error(.automation, "Accessibility permission denied")
+            appState.addActivity("Accessibility permission denied", platform: platform)
+            coordinator?.reportError(.permissionDenied(.accessibility))
+        case .elementNotFound, .macWhisperNotRunning, .timeout, .actionFailed:
+            // Treat all of these as transient and retry indefinitely
+            // while the meeting is still active. MacWhisper may be
+            // launching, the menu may be loading, AX cache may be cold,
+            // or the user may have just quit MacWhisper.
+            scheduleStartRecordingRetry(error: error, platform: platform)
+        }
+    }
+
+    private func scheduleStartRecordingRetry(error: AXError, platform: Platform) {
+        startRecordingRetryCount += 1
+        let attempt = startRecordingRetryCount
+        let delay = Self.startRecordingRetryDelay(attempt: attempt)
+        DetectionLogger.shared.automation(
+            "Start recording transient failure (\(error)), retrying in \(delay)s (attempt \(attempt))",
+            action: "startRecording"
+        )
+        // Activity log: once on first failure, then every 10th attempt.
+        if attempt == 1 || attempt % 10 == 0 {
+            appState.addActivity(
+                "Retrying in background (attempt \(attempt)): \(error)",
+                platform: platform
+            )
+        }
+        // If we've failed to find the menu item ≥3 times in a row, surface
+        // it visibly — likely a MacWhisper menu rename.
+        if attempt >= 3, case .elementNotFound = error {
+            appState.macWhisperMenuItemMissing = platform
+        }
+        DispatchQueue.main.asyncAfter(deadline: .now() + delay) { [weak self] in
+            self?.attemptStartRecording(platform: platform)
         }
     }
 
@@ -386,21 +412,24 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
 
         let controller = macWhisperController
         let stateRef = appState
-        controller.launchIfNeeded { launched in
+        controller.launchIfNeeded { launchResult in
             Task { @MainActor in
-                guard launched else {
-                    stateRef.addActivity("Failed to launch MacWhisper")
+                switch launchResult {
+                case .failure(let error):
+                    stateRef.addActivity("Failed to launch MacWhisper: \(error)")
                     return
-                }
-                controller.manualRecord(buttonName: buttonName) { result in
-                    Task { @MainActor in
-                        switch result {
-                        case .success:
-                            let platform = Self.platformForButton(buttonName)
-                            stateRef.updateState(.recording(platform: platform))
-                            stateRef.addActivity("Recording started: \(buttonName)")
-                        case .failure(let error):
-                            stateRef.addActivity("Recording failed: \(error)")
+                case .success:
+                    controller.manualRecord(buttonName: buttonName) { result in
+                        Task { @MainActor in
+                            switch result {
+                            case .success:
+                                let platform = Self.platformForButton(buttonName)
+                                stateRef.updateState(.recording(platform: platform))
+                                self.startRecordingObservation()
+                                stateRef.addActivity("Manual record issued: \(buttonName)")
+                            case .failure(let error):
+                                stateRef.addActivity("Recording failed: \(error)")
+                            }
                         }
                     }
                 }
@@ -416,6 +445,72 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         case "Record Comet", "Record Chrome": .browser
         case "Record Chime": .chime
         default: .browser
+        }
+    }
+
+    // MARK: - Recording Observation (Reality Poll)
+
+    /// Start polling MacWhisper for its actual recording state. The poll
+    /// drives `appState.macWhisperObservedRecording`, which is what the UI
+    /// surfaces as "Recording" (vs "Starting..."). Safe to call repeatedly.
+    private func startRecordingObservation() {
+        if recordingObservationTimer != nil { return }
+        let timer = DispatchSource.makeTimerSource(queue: .main)
+        timer.schedule(deadline: .now() + 0.5, repeating: 2.0, leeway: .milliseconds(500))
+        timer.setEventHandler { [weak self] in
+            self?.pollRecordingObservation()
+        }
+        timer.resume()
+        recordingObservationTimer = timer
+    }
+
+    private func stopRecordingObservation() {
+        recordingObservationTimer?.cancel()
+        recordingObservationTimer = nil
+        appState.macWhisperObservedRecording = false
+        appState.macWhisperMenuItemMissing = nil
+    }
+
+    private func pollRecordingObservation() {
+        // Self-stop once intent leaves .recording and there's nothing left
+        // to confirm. Covers paths that transition to .idle/.error without
+        // going through handleStopRecording (e.g. clearError, sleep reset).
+        if case .recording = appState.meetingState {
+            // continue polling
+        } else if !appState.macWhisperObservedRecording {
+            stopRecordingObservation()
+            return
+        }
+
+        let stateRef = appState
+        macWhisperController.checkRecordingStatus { observed in
+            Task { @MainActor in
+                let previous = stateRef.macWhisperObservedRecording
+                if previous == observed { return }
+                stateRef.macWhisperObservedRecording = observed
+                let platform = stateRef.activePlatform
+                if observed {
+                    // false → true: MacWhisper is actually recording now.
+                    if case .recording = stateRef.meetingState {
+                        stateRef.addActivity(
+                            "Recording confirmed" +
+                                (platform.map { " for \($0.displayName)" } ?? ""),
+                            platform: platform
+                        )
+                    }
+                } else {
+                    // true → false: MacWhisper stopped recording. If intent
+                    // is still .recording, that means MacWhisper was stopped
+                    // externally (user pressed Finish, or MacWhisper crashed).
+                    if case .recording = stateRef.meetingState {
+                        stateRef.addActivity(
+                            "Recording stopped externally", platform: platform
+                        )
+                        stateRef.updateState(.idle)
+                        self.stopRecordingObservation()
+                    }
+                }
+            }
         }
     }
 
@@ -439,6 +534,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
                 switch result {
                 case .success:
                     stateRef.updateState(.idle)
+                    self.stopRecordingObservation()
                     stateRef.addActivity("Recording stopped")
                 case .failure(let error):
                     DetectionLogger.shared.error(.automation, "Stop recording failed: \(error)")

--- a/Sources/App/StatusBarController.swift
+++ b/Sources/App/StatusBarController.swift
@@ -71,16 +71,26 @@ final class StatusBarController {
 
     private func updateIcon() {
         guard let button = statusItem.button else { return }
+        // Menu-rename alert takes precedence over normal state icons —
+        // it's actionable and the user needs to see it.
         let symbolName: String
-        switch appState.meetingState {
-        case .idle:
-            symbolName = appState.permissionsGranted ? "mic.circle" : "exclamationmark.triangle"
-        case .detecting:
-            symbolName = "mic.badge.xmark"
-        case .recording:
-            symbolName = "record.circle.fill"
-        case .error:
-            symbolName = "exclamationmark.triangle"
+        if appState.macWhisperMenuItemMissing != nil {
+            symbolName = "exclamationmark.triangle.fill"
+        } else {
+            switch appState.meetingState {
+            case .idle:
+                symbolName = appState.permissionsGranted ? "mic.circle" : "exclamationmark.triangle"
+            case .detecting:
+                symbolName = "mic.badge.xmark"
+            case .recording:
+                // Different icon while we're issuing/retrying the start command
+                // vs once MacWhisper has confirmed it's actually recording.
+                symbolName = appState.macWhisperObservedRecording
+                    ? "record.circle.fill"
+                    : "record.circle"
+            case .error:
+                symbolName = "exclamationmark.triangle"
+            }
         }
         button.image = NSImage(
             systemSymbolName: symbolName,

--- a/Sources/Automation/AXError.swift
+++ b/Sources/Automation/AXError.swift
@@ -2,6 +2,7 @@ import Foundation
 
 enum AXError: Error, CustomStringConvertible, Sendable {
     case macWhisperNotRunning
+    case macWhisperNotInstalled
     case elementNotFound(description: String)
     case actionFailed(element: String, action: String, code: Int32)
     case timeout
@@ -10,6 +11,7 @@ enum AXError: Error, CustomStringConvertible, Sendable {
     var description: String {
         switch self {
         case .macWhisperNotRunning: "MacWhisper is not running"
+        case .macWhisperNotInstalled: "MacWhisper is not installed"
         case .elementNotFound(let desc): "Element not found: \(desc)"
         case .actionFailed(let el, let action, let code):
             "Action '\(action)' failed on '\(el)' (code: \(code))"

--- a/Sources/Automation/AccessibilityHelper.swift
+++ b/Sources/Automation/AccessibilityHelper.swift
@@ -76,6 +76,71 @@ enum AccessibilityHelper {
         return nil
     }
 
+    /// Recursive search for AXMenuItem by title. Tries exact match first,
+    /// then falls back to case-insensitive `contains` so subtle renames
+    /// (e.g. "Teams" → "Microsoft Teams") still resolve.
+    static func findMenuItemByFuzzyTitle(
+        _ parent: AXUIElement,
+        title: String,
+        maxDepth: Int = 6
+    ) -> AXUIElement? {
+        if let exact = findMenuItemByTitle(parent, title: title, maxDepth: maxDepth) {
+            return exact
+        }
+        let needle = title.lowercased()
+        return findMenuItemMatching(parent, maxDepth: maxDepth) { itemTitle in
+            itemTitle.lowercased().contains(needle)
+        }
+    }
+
+    /// Recursive search for AXMenuItem whose title satisfies a predicate.
+    static func findMenuItemMatching(
+        _ parent: AXUIElement,
+        maxDepth: Int = 6,
+        currentDepth: Int = 0,
+        predicate: (String) -> Bool
+    ) -> AXUIElement? {
+        guard currentDepth <= maxDepth else { return nil }
+        let role: String = attribute(parent, kAXRoleAttribute) ?? ""
+        let itemTitle: String = attribute(parent, kAXTitleAttribute) ?? ""
+        if role == "AXMenuItem" && !itemTitle.isEmpty && predicate(itemTitle) {
+            return parent
+        }
+        for child in arrayAttribute(parent, kAXChildrenAttribute) {
+            if let found = findMenuItemMatching(
+                child, maxDepth: maxDepth,
+                currentDepth: currentDepth + 1,
+                predicate: predicate
+            ) {
+                return found
+            }
+        }
+        return nil
+    }
+
+    /// Collect all non-empty AXMenuItem titles under the given element.
+    static func enumerateMenuItemTitles(
+        _ parent: AXUIElement,
+        maxDepth: Int = 4,
+        currentDepth: Int = 0
+    ) -> [String] {
+        guard currentDepth <= maxDepth else { return [] }
+        var titles: [String] = []
+        let role: String = attribute(parent, kAXRoleAttribute) ?? ""
+        if role == "AXMenuItem" {
+            let title: String = attribute(parent, kAXTitleAttribute) ?? ""
+            if !title.isEmpty {
+                titles.append(title)
+            }
+        }
+        for child in arrayAttribute(parent, kAXChildrenAttribute) {
+            titles.append(contentsOf: enumerateMenuItemTitles(
+                child, maxDepth: maxDepth, currentDepth: currentDepth + 1
+            ))
+        }
+        return titles
+    }
+
     /// Recursive search for AXMenuItem whose title starts with a prefix
     /// (e.g. "Recording" for "Recording 00:03:42").
     static func findMenuItemWithTitlePrefix(

--- a/Sources/Automation/MacWhisperController+FaceTime.swift
+++ b/Sources/Automation/MacWhisperController+FaceTime.swift
@@ -1,0 +1,35 @@
+import ApplicationServices
+import Foundation
+
+extension MacWhisperController {
+    /// FaceTime fallback: MacWhisper has no FaceTime item in the Record Meeting
+    /// submenu, so press the "Record All System Audio" button in the main window.
+    func performStartFaceTimeRecording(
+        appElement: AXUIElement
+    ) -> Result<Void, AXError> {
+        DetectionLogger.shared.automation(
+            "FaceTime: navigating to All System Audio fallback", action: "startRecording"
+        )
+
+        let candidates = ["Record All System Audio", "All System Audio"]
+        let windows = AccessibilityHelper.arrayAttribute(appElement, kAXWindowsAttribute)
+        for window in windows {
+            for description in candidates {
+                guard let button = AccessibilityHelper.findByDescription(
+                    window, description: description
+                ) else { continue }
+                let result = AccessibilityHelper.press(button)
+                if case .success = result {
+                    DetectionLogger.shared.automation(
+                        "Recording started for FaceTime (All System Audio)",
+                        action: "startRecording"
+                    )
+                }
+                return result
+            }
+        }
+        return .failure(
+            .elementNotFound(description: "Record All System Audio / All System Audio")
+        )
+    }
+}

--- a/Sources/Automation/MacWhisperController.swift
+++ b/Sources/Automation/MacWhisperController.swift
@@ -50,14 +50,17 @@ final class MacWhisperController: Sendable {
     }
 
     /// Launch MacWhisper if not running (background, no activation).
-    func launchIfNeeded(completion: @escaping @Sendable (Bool) -> Void) {
+    /// Returns `.macWhisperNotInstalled` when MacWhisper isn't installed at all,
+    /// `.macWhisperNotRunning` when launch was attempted but the app didn't
+    /// become accessible within the wait window (transient — caller can retry).
+    func launchIfNeeded(completion: @escaping @Sendable (Result<Void, AXError>) -> Void) {
         if findMacWhisperApp() != nil {
-            completion(true)
+            completion(.success(()))
             return
         }
         guard let url = NSWorkspace.shared.urlForApplication(withBundleIdentifier: bundleID) else {
             DetectionLogger.shared.error(.automation, "MacWhisper not installed")
-            completion(false)
+            completion(.failure(.macWhisperNotInstalled))
             return
         }
         let config = NSWorkspace.OpenConfiguration()
@@ -67,26 +70,31 @@ final class MacWhisperController: Sendable {
                 DetectionLogger.shared.error(
                     .automation, "Failed to launch MacWhisper: \(error.localizedDescription)"
                 )
-                completion(false)
+                completion(.failure(.macWhisperNotRunning))
                 return
             }
             // Wait for MacWhisper to become accessible
             DispatchQueue.main.asyncAfter(deadline: .now() + 3.0) {
-                completion(self.findMacWhisperApp() != nil)
+                if self.findMacWhisperApp() != nil {
+                    completion(.success(()))
+                } else {
+                    completion(.failure(.macWhisperNotRunning))
+                }
             }
         }
     }
 
     /// Launch MacWhisper in background on app startup so it's ready when needed.
     func launchInBackground() {
-        launchIfNeeded { launched in
-            if launched {
+        launchIfNeeded { result in
+            switch result {
+            case .success:
                 DetectionLogger.shared.automation(
                     "MacWhisper launched at startup", action: "launchBackground"
                 )
-            } else {
+            case .failure(let error):
                 DetectionLogger.shared.error(
-                    .automation, "Failed to launch MacWhisper at startup"
+                    .automation, "Failed to launch MacWhisper at startup: \(error)"
                 )
             }
         }
@@ -110,15 +118,17 @@ final class MacWhisperController: Sendable {
             )
         }
         DispatchQueue.main.asyncAfter(deadline: .now() + 1.5) { [self] in
-            self.launchIfNeeded { launched in
-                if launched {
+            self.launchIfNeeded { result in
+                switch result {
+                case .success:
                     DetectionLogger.shared.automation(
                         "MacWhisper relaunched successfully", action: "forceQuitRelaunch"
                     )
-                } else {
-                    DetectionLogger.shared.error(.automation, "MacWhisper relaunch failed")
+                    completion(true)
+                case .failure(let error):
+                    DetectionLogger.shared.error(.automation, "MacWhisper relaunch failed: \(error)")
+                    completion(false)
                 }
-                completion(launched)
             }
         }
     }
@@ -178,11 +188,18 @@ final class MacWhisperController: Sendable {
         }
         Thread.sleep(forTimeInterval: 0.3)
 
-        guard let recordMeeting = AccessibilityHelper.findMenuItemByTitle(
+        guard let recordMeeting = AccessibilityHelper.findMenuItemByFuzzyTitle(
             menuExtra, title: "Record Meeting"
         ) else {
+            let seen = AccessibilityHelper.enumerateMenuItemTitles(menuExtra)
+            DetectionLogger.shared.error(
+                .automation,
+                "'Record Meeting' menu item not found. Top-level items: \(seen.joined(separator: ", "))"
+            )
             AXUIElementPerformAction(menuExtra, kAXCancelAction as CFString)
-            return .failure(.elementNotFound(description: "Record Meeting"))
+            return .failure(.elementNotFound(
+                description: "Record Meeting (saw: \(seen.joined(separator: ", ")))"
+            ))
         }
 
         DetectionLogger.shared.automation(
@@ -197,11 +214,18 @@ final class MacWhisperController: Sendable {
         }
         Thread.sleep(forTimeInterval: 0.3)
 
-        guard let platformItem = AccessibilityHelper.findMenuItemByTitle(
+        guard let platformItem = AccessibilityHelper.findMenuItemByFuzzyTitle(
             recordMeeting, title: menuTitle
         ) else {
+            let seen = AccessibilityHelper.enumerateMenuItemTitles(recordMeeting)
+            DetectionLogger.shared.error(
+                .automation,
+                "'\(menuTitle)' menu item not found under Record Meeting. Submenu items: \(seen.joined(separator: ", "))"
+            )
             AXUIElementPerformAction(menuExtra, kAXCancelAction as CFString)
-            return .failure(.elementNotFound(description: menuTitle))
+            return .failure(.elementNotFound(
+                description: "\(menuTitle) (Record Meeting submenu has: \(seen.joined(separator: ", ")))"
+            ))
         }
 
         DetectionLogger.shared.automation(

--- a/Sources/Automation/MacWhisperController.swift
+++ b/Sources/Automation/MacWhisperController.swift
@@ -277,46 +277,6 @@ final class MacWhisperController: Sendable {
         }
     }
 
-    /// FaceTime fallback: use "Record All System Audio" or "All System Audio".
-    private func performStartFaceTimeRecording(
-        appElement: AXUIElement
-    ) -> Result<Void, AXError> {
-        DetectionLogger.shared.automation(
-            "FaceTime: navigating to All System Audio fallback", action: "startRecording"
-        )
-
-        let windows = AccessibilityHelper.arrayAttribute(appElement, kAXWindowsAttribute)
-        for window in windows {
-            if let button = AccessibilityHelper.findByDescription(
-                window, description: "Record All System Audio"
-            ) {
-                let result = AccessibilityHelper.press(button)
-                if case .success = result {
-                    DetectionLogger.shared.automation(
-                        "Recording started for FaceTime (All System Audio)",
-                        action: "startRecording"
-                    )
-                }
-                return result
-            }
-            if let button = AccessibilityHelper.findByDescription(
-                window, description: "All System Audio"
-            ) {
-                let result = AccessibilityHelper.press(button)
-                if case .success = result {
-                    DetectionLogger.shared.automation(
-                        "Recording started for FaceTime (All System Audio)",
-                        action: "startRecording"
-                    )
-                }
-                return result
-            }
-        }
-        return .failure(
-            .elementNotFound(description: "Record All System Audio / All System Audio")
-        )
-    }
-
     /// Stop recording — press "Finish" on an existing finish-recording dialog,
     /// or find the active recording in the sidebar to trigger the dialog first.
     private func performStopRecording() -> Result<Void, AXError> {

--- a/Sources/Core/AppState.swift
+++ b/Sources/Core/AppState.swift
@@ -10,6 +10,17 @@ final class AppState {
     var permissionsGranted: Bool = false
     var extensionConnected: Bool = false
 
+    /// Whether MacWhisper itself currently shows an active recording row in its
+    /// sidebar. Populated by the 2s polling loop in AppDelegate. Distinct from
+    /// `meetingState == .recording`, which reflects *intent* (we've sent or are
+    /// retrying the start command).
+    var macWhisperObservedRecording: Bool = false
+
+    /// When set, MacWhisper's "Record Meeting" submenu does not contain a menu
+    /// item matching the platform's expected title (subtle rename detected).
+    /// Surface via the status bar alert overlay and a popover warning row.
+    var macWhisperMenuItemMissing: Platform?
+
     // Version tracking
     let appVersion: String = Bundle.main.object(forInfoDictionaryKey: "CFBundleShortVersionString") as? String ?? "0.0.0"
     var extensionVersion: String?
@@ -27,9 +38,18 @@ final class AppState {
 
     var showOnboarding: Bool { !permissionsGranted }
 
+    /// True only when both *intent* is recording AND MacWhisper's sidebar
+    /// confirms an active recording row. Prevents the UI from claiming
+    /// "Recording" while the AX start command is still retrying.
     var isRecording: Bool {
-        if case .recording = meetingState { return true }
-        return false
+        guard case .recording = meetingState else { return false }
+        return macWhisperObservedRecording
+    }
+
+    /// Intent says we should be recording, but MacWhisper hasn't confirmed yet.
+    var isStartingRecording: Bool {
+        guard case .recording = meetingState else { return false }
+        return !macWhisperObservedRecording
     }
 
     var isDetecting: Bool {
@@ -53,7 +73,10 @@ final class AppState {
         switch meetingState {
         case .idle: "Idle - No meeting detected"
         case .detecting(let platform, _): "Detecting \(platform.displayName)..."
-        case .recording(let platform): "Recording \(platform.displayName)"
+        case .recording(let platform):
+            macWhisperObservedRecording
+                ? "Recording \(platform.displayName)"
+                : "Starting \(platform.displayName)..."
         case .error(let kind): "Error: \(kind.userDescription)"
         }
     }
@@ -80,6 +103,10 @@ final class AppState {
             currentPlatform = platform
         case .idle:
             currentPlatform = nil
+            // Drop stale observation when we leave any recording intent.
+            macWhisperObservedRecording = false
+        case .error:
+            macWhisperObservedRecording = false
         default:
             break
         }

--- a/Sources/Core/Types.swift
+++ b/Sources/Core/Types.swift
@@ -49,6 +49,7 @@ enum MeetingState: Equatable, Sendable {
 enum ErrorKind: Equatable, Sendable {
     case macWhisperUnresponsive
     case macWhisperNotRunning
+    case macWhisperNotInstalled
     case axElementNotFound(String)
     case permissionDenied(Permission)
     case webSocketPortUnavailable
@@ -57,6 +58,7 @@ enum ErrorKind: Equatable, Sendable {
         switch (lhs, rhs) {
         case (.macWhisperUnresponsive, .macWhisperUnresponsive): true
         case (.macWhisperNotRunning, .macWhisperNotRunning): true
+        case (.macWhisperNotInstalled, .macWhisperNotInstalled): true
         case (.axElementNotFound(let l), .axElementNotFound(let r)): l == r
         case (.permissionDenied(let l), .permissionDenied(let r)): l == r
         case (.webSocketPortUnavailable, .webSocketPortUnavailable): true
@@ -74,6 +76,7 @@ extension ErrorKind {
         switch self {
         case .macWhisperUnresponsive: "MacWhisper is not responding"
         case .macWhisperNotRunning: "MacWhisper is not running"
+        case .macWhisperNotInstalled: "MacWhisper is not installed"
         case .axElementNotFound(let desc): "UI element not found: \(desc)"
         case .permissionDenied(let perm): "\(perm.rawValue) permission denied"
         case .webSocketPortUnavailable: "WebSocket port 8765 unavailable"

--- a/Sources/UI/StatusMenuView.swift
+++ b/Sources/UI/StatusMenuView.swift
@@ -13,6 +13,11 @@ struct StatusMenuView: View {
 
             Divider()
 
+            if let missingPlatform = appState.macWhisperMenuItemMissing {
+                menuMismatchWarning(platform: missingPlatform)
+                Divider()
+            }
+
             if case .error(let errorKind) = appState.meetingState {
                 ErrorView(
                     errorKind: errorKind,
@@ -22,10 +27,8 @@ struct StatusMenuView: View {
                 Divider()
             }
 
-            if appState.isRecording {
-                if case .recording(let platform) = appState.meetingState {
-                    recordingInfo(platform: platform)
-                }
+            if case .recording(let platform) = appState.meetingState {
+                recordingInfo(platform: platform)
                 stopButton
                 Divider()
             } else {
@@ -72,10 +75,17 @@ struct StatusMenuView: View {
                 .foregroundStyle(.orange)
                 .symbolEffect(.pulse)
         case .recording:
-            Image(systemName: "record.circle.fill")
-                .font(.title)
-                .foregroundStyle(.red)
-                .symbolEffect(.pulse)
+            if appState.macWhisperObservedRecording {
+                Image(systemName: "record.circle.fill")
+                    .font(.title)
+                    .foregroundStyle(.red)
+                    .symbolEffect(.pulse)
+            } else {
+                Image(systemName: "record.circle")
+                    .font(.title)
+                    .foregroundStyle(.orange)
+                    .symbolEffect(.pulse)
+            }
         case .error:
             Image(systemName: "exclamationmark.triangle.fill")
                 .font(.title)
@@ -84,12 +94,13 @@ struct StatusMenuView: View {
     }
 
     private func recordingInfo(platform: Platform) -> some View {
-        HStack {
-            Image(systemName: "record.circle.fill")
-                .foregroundStyle(.red)
+        let confirmed = appState.macWhisperObservedRecording
+        return HStack {
+            Image(systemName: confirmed ? "record.circle.fill" : "record.circle")
+                .foregroundStyle(confirmed ? .red : .orange)
                 .symbolEffect(.pulse)
             VStack(alignment: .leading) {
-                Text("Recording")
+                Text(confirmed ? "Recording" : "Starting...")
                     .font(.caption)
                     .foregroundStyle(.secondary)
                 Text(platform.displayName)
@@ -99,8 +110,26 @@ struct StatusMenuView: View {
             Spacer()
         }
         .padding(8)
-        .background(.red.opacity(0.1))
+        .background((confirmed ? Color.red : Color.orange).opacity(0.1))
         .cornerRadius(8)
+    }
+
+    private func menuMismatchWarning(platform: Platform) -> some View {
+        HStack(alignment: .top, spacing: 6) {
+            Image(systemName: "exclamationmark.triangle.fill")
+                .foregroundStyle(.yellow)
+            VStack(alignment: .leading, spacing: 2) {
+                Text("MacWhisper menu may have changed")
+                    .font(.caption)
+                    .fontWeight(.medium)
+                Text("Couldn't find a '\(platform.displayName)' item under Record Meeting. See logs for the titles MacWhisper is exposing.")
+                    .font(.caption2)
+                    .foregroundStyle(.secondary)
+            }
+        }
+        .padding(8)
+        .background(.yellow.opacity(0.1))
+        .cornerRadius(6)
     }
 
     private static let manualTargets: [(label: String, button: String)] = [


### PR DESCRIPTION
## Summary
- **Reality-driven recording status.** A 2s poll of MacWhisper's sidebar now drives `AppState.macWhisperObservedRecording`. UI shows "Starting <platform>..." with an orange unfilled `record.circle` until MacWhisper actually has an active recording row, then flips to "Recording" with the filled red icon. External stops (user clicks Finish in MacWhisper, or it crashes mid-record) are detected and surfaced as "Recording stopped externally" with the state returning to idle.
- **Resilient Teams menu matching.** `findMenuItemByFuzzyTitle` tries exact, then case-insensitive `contains` — so subtle MacWhisper renames like `Teams` → `Microsoft Teams` keep working. On miss, the actual submenu titles MacWhisper exposes are enumerated and logged. After 3 consecutive `.elementNotFound` retries during a real start attempt, the status bar icon turns into a yellow alert triangle and a popover row tells the user the menu has changed.
- **Indefinite retry when MacWhisper isn't running.** Each retry iteration now re-runs `launchIfNeeded`, so MacWhisper being quit or crashing mid-meeting auto-recovers via the existing 2s/5s/10s/30s backoff. New `AXError.macWhisperNotInstalled` / `ErrorKind.macWhisperNotInstalled` distinguishes the only genuinely permanent failure (MacWhisper not installed) from the transient "not currently running" case.

## Test plan
- [ ] **Reality status, fresh launch**: Quit MacWhisper. Join a Teams meeting. Verify status shows "Starting Microsoft Teams..." with an orange unfilled circle while MacWhisper launches; flips to "Recording" with filled red circle once MacWhisper's sidebar shows the active row. Activity log: single "Recording confirmed" entry, not premature "Recording started".
- [ ] **External stop detection**: Mid-recording, click Finish in MacWhisper directly. Within ~2s the app surfaces "Recording stopped externally" and transitions to idle.
- [ ] **Fuzzy menu match**: Join a Teams meeting and confirm recording starts (logs should show which title matched). Optionally temporarily change `Platform.macWhisperMenuTitle` for an unused platform to a wrong value to verify the enumerate-on-miss log lists what MacWhisper actually exposes and the alert overlay appears.
- [ ] **Not-running retry**: Mid-meeting, force-quit MacWhisper via Activity Monitor. Verify status returns to "Starting <platform>...", retries continue every 2-30s, MacWhisper relaunches automatically, recording is confirmed within ~10s.
- [ ] **Not-installed bail**: Temporarily move `/Applications/MacWhisper.app` aside. Trigger a recording. Verify the new "MacWhisper is not installed" error appears and no infinite retry loop runs.
- [ ] **Regression**: Zoom / Slack / Chime / FaceTime fallback / manual record buttons / Stop Recording still work.