### PR TITLE
Adapt to current MacWhisper menu extra layout

### DIFF
--- a/Sources/Automation/MacWhisperController+LegacyStop.swift
+++ b/Sources/Automation/MacWhisperController+LegacyStop.swift
@@ -1,0 +1,54 @@
+import ApplicationServices
+import Foundation
+
+/// Legacy stop-recording helpers for older MacWhisper versions that surface a
+/// "Finish Recording?" dialog triggered by clicking the active recording row in
+/// the sidebar. Current MacWhisper exposes a top-level "Stop Recording" item in
+/// its status-menu extra instead; these are kept as a fallback.
+extension MacWhisperController {
+    func pressFinishDialogButton(_ appElement: AXUIElement) -> Result<Void, AXError>? {
+        let windows = AccessibilityHelper.arrayAttribute(appElement, kAXWindowsAttribute)
+        for window in windows {
+            let subrole: String? = AccessibilityHelper.attribute(window, kAXSubroleAttribute)
+            guard subrole == "AXSystemDialog" else { continue }
+
+            if let finishButton = AccessibilityHelper.findByDescription(
+                window, description: "Finish"
+            ) {
+                let result = AccessibilityHelper.press(finishButton)
+                switch result {
+                case .success:
+                    DetectionLogger.shared.automation(
+                        "Recording stopped via Finish button", action: "stopRecording"
+                    )
+                case .failure(let error):
+                    DetectionLogger.shared.error(
+                        .automation, "Failed to press Finish: \(error)"
+                    )
+                }
+                return result
+            }
+        }
+        return nil
+    }
+
+    /// Find the active recording row in the sidebar (the cell containing "Meeting - ..." text).
+    func findActiveRecordingRow(_ element: AXUIElement, depth: Int = 0) -> AXUIElement? {
+        guard depth < 15 else { return nil }
+        let role: String = AccessibilityHelper.attribute(element, kAXRoleAttribute) ?? ""
+        if role == "AXCell" {
+            for child in AccessibilityHelper.arrayAttribute(element, kAXChildrenAttribute) {
+                let value: String = AccessibilityHelper.attribute(child, kAXValueAttribute) ?? ""
+                if value.hasPrefix("Meeting") {
+                    return element
+                }
+            }
+        }
+        for child in AccessibilityHelper.arrayAttribute(element, kAXChildrenAttribute) {
+            if let found = findActiveRecordingRow(child, depth: depth + 1) {
+                return found
+            }
+        }
+        return nil
+    }
+}

--- a/Sources/Automation/MacWhisperController.swift
+++ b/Sources/Automation/MacWhisperController.swift
@@ -22,6 +22,18 @@ final class MacWhisperController: Sendable {
         }
     }
 
+    /// AXDescription used by per-platform Record buttons in MacWhisper's main
+    /// window. These exist regardless of whether MacWhisper's own meeting
+    /// detection has fired, so they're our last-resort fallback when the
+    /// status-menu extra doesn't expose a Record item.
+    private static let windowButtonDescription: [Platform: String] = [
+        .teams: "Record Teams",
+        .zoom: "Record Zoom",
+        .slack: "Record Slack",
+        .chime: "Record Chime",
+        .browser: "Record Comet"
+    ]
+
     /// Manual recording by raw button name (e.g. "Record Chrome", "Record All System Audio").
     func manualRecord(
         buttonName: String,
@@ -148,23 +160,88 @@ final class MacWhisperController: Sendable {
         return .success(element)
     }
 
-    /// Start recording via MacWhisper's status-menu "Record Meeting" submenu.
-    /// FaceTime falls through to a window-based fallback because the menu has no FaceTime item.
+    /// Start recording. Tries paths in order:
+    ///   1. New flat menu-extra item ("Record <Platform> Meeting")
+    ///   2. Legacy "Record Meeting > <Platform>" submenu
+    ///   3. In-window per-platform Record button (AXDescription "Record <Platform>")
+    /// FaceTime has no platform-specific entry — it falls through to a
+    /// window-based "Record All System Audio" fallback (in the +FaceTime extension).
     private func performStartRecording(platform: Platform) -> Result<Void, AXError> {
         switch createAppElement() {
         case .failure(let error):
             return .failure(error)
         case .success(let appElement):
+            // Pre-check: if MacWhisper is already recording (user started it
+            // manually, or a previous attempt succeeded), don't try to start a
+            // second recording — that's how we end up with duplicate files.
+            if performCheckRecording() {
+                DetectionLogger.shared.automation(
+                    "MacWhisper is already recording — treating start as no-op",
+                    action: "startRecording"
+                )
+                return .success(())
+            }
             if let menuTitle = platform.macWhisperMenuTitle {
-                return performStartRecordingViaMenu(
+                let menuResult = performStartRecordingViaMenu(
                     appElement: appElement, menuTitle: menuTitle, platform: platform
                 )
+                if case .success = menuResult { return menuResult }
+
+                // Final fallback: in-window "Record <Platform>" button by AXDescription.
+                // Exists in MacWhisper's main window regardless of MacWhisper's own
+                // meeting detection state, so this catches the case where our
+                // detector fired but MacWhisper's didn't.
+                if let buttonDesc = Self.windowButtonDescription[platform] {
+                    if let result = pressWindowRecordButton(
+                        appElement: appElement, description: buttonDesc, platform: platform
+                    ) {
+                        return result
+                    }
+                }
+                return menuResult
             }
             return performStartFaceTimeRecording(appElement: appElement)
         }
     }
 
-    /// Navigate the status-menu extra → "Record Meeting" submenu → <platform> item.
+    /// Press the in-window "Record <Platform>" button by AXDescription.
+    /// Returns `nil` when the button isn't present (caller should propagate
+    /// the upstream error). Returns success/failure when the button was found.
+    private func pressWindowRecordButton(
+        appElement: AXUIElement, description: String, platform: Platform
+    ) -> Result<Void, AXError>? {
+        let windows = AccessibilityHelper.arrayAttribute(appElement, kAXWindowsAttribute)
+        for window in windows {
+            guard let button = AccessibilityHelper.findByDescription(
+                window, description: description
+            ) else { continue }
+            DetectionLogger.shared.automation(
+                "Falling back to in-window '\(description)' button", action: "startRecording"
+            )
+            let result = AccessibilityHelper.press(button)
+            if case .success = result {
+                DetectionLogger.shared.automation(
+                    "Recording started for \(platform.displayName) via window button",
+                    action: "startRecording"
+                )
+            }
+            return result
+        }
+        return nil
+    }
+
+    /// Drive the status-menu extra to start recording. MacWhisper has shipped
+    /// two layouts for this menu over time:
+    ///
+    /// 1. **Flat (current)** — a single top-level item "Record <Platform> Meeting"
+    ///    (e.g. "Record Teams Meeting") sits directly in the menu extra. Only
+    ///    one platform's item shows at a time, picked by MacWhisper's own
+    ///    meeting detection.
+    /// 2. **Submenu (older)** — a "Record Meeting" item expands to a submenu
+    ///    containing per-platform leaves ("Teams", "Zoom", ...).
+    ///
+    /// Try the flat layout first, fall back to the submenu layout, then log
+    /// the items we actually saw so misses are easy to diagnose.
     private func performStartRecordingViaMenu(
         appElement: AXUIElement, menuTitle: String, platform: Platform
     ) -> Result<Void, AXError> {
@@ -188,62 +265,66 @@ final class MacWhisperController: Sendable {
         }
         Thread.sleep(forTimeInterval: 0.3)
 
-        guard let recordMeeting = AccessibilityHelper.findMenuItemByFuzzyTitle(
-            menuExtra, title: "Record Meeting"
-        ) else {
-            let seen = AccessibilityHelper.enumerateMenuItemTitles(menuExtra)
-            DetectionLogger.shared.error(
-                .automation,
-                "'Record Meeting' menu item not found. Top-level items: \(seen.joined(separator: ", "))"
-            )
-            AXUIElementPerformAction(menuExtra, kAXCancelAction as CFString)
-            return .failure(.elementNotFound(
-                description: "Record Meeting (saw: \(seen.joined(separator: ", ")))"
-            ))
-        }
-
-        DetectionLogger.shared.automation(
-            "Expanding Record Meeting submenu", action: "startRecording"
-        )
-        let expandErr = AXUIElementPerformAction(recordMeeting, kAXPressAction as CFString)
-        guard expandErr == .success else {
-            AXUIElementPerformAction(menuExtra, kAXCancelAction as CFString)
-            return .failure(.actionFailed(
-                element: "AXMenuItem:Record Meeting", action: "AXPress", code: expandErr.rawValue
-            ))
-        }
-        Thread.sleep(forTimeInterval: 0.3)
-
-        guard let platformItem = AccessibilityHelper.findMenuItemByFuzzyTitle(
-            recordMeeting, title: menuTitle
-        ) else {
-            let seen = AccessibilityHelper.enumerateMenuItemTitles(recordMeeting)
-            DetectionLogger.shared.error(
-                .automation,
-                "'\(menuTitle)' menu item not found under Record Meeting. Submenu items: \(seen.joined(separator: ", "))"
-            )
-            AXUIElementPerformAction(menuExtra, kAXCancelAction as CFString)
-            return .failure(.elementNotFound(
-                description: "\(menuTitle) (Record Meeting submenu has: \(seen.joined(separator: ", ")))"
-            ))
-        }
-
-        DetectionLogger.shared.automation(
-            "Pressing '\(menuTitle)' menu item", action: "startRecording"
-        )
-        let result = AccessibilityHelper.press(platformItem)
-        switch result {
-        case .success:
+        // Layout 1: flat "Record <Platform> Meeting" at the top level.
+        // Match "Record " (with trailing space) to avoid hitting "Recording <Platform> Meeting"
+        // (which is the status indicator that appears while recording is active).
+        let menuTitleLower = menuTitle.lowercased()
+        if let item = AccessibilityHelper.findMenuItemMatching(menuExtra, maxDepth: 4) { title in
+            let lc = title.lowercased()
+            return lc.hasPrefix("record ") && lc.contains(menuTitleLower)
+        } {
+            let foundTitle: String = AccessibilityHelper.attribute(item, kAXTitleAttribute) ?? ""
             DetectionLogger.shared.automation(
-                "Recording started for \(platform.displayName)", action: "startRecording"
+                "Pressing top-level '\(foundTitle)' item", action: "startRecording"
             )
-        case .failure(let error):
+            let result = AccessibilityHelper.press(item)
+            if case .success = result {
+                DetectionLogger.shared.automation(
+                    "Recording started for \(platform.displayName) via '\(foundTitle)'",
+                    action: "startRecording"
+                )
+                return result
+            }
             AXUIElementPerformAction(menuExtra, kAXCancelAction as CFString)
-            DetectionLogger.shared.error(
-                .automation, "Failed to press '\(menuTitle)': \(error)"
-            )
+            return result
         }
-        return result
+
+        // Layout 2: legacy "Record Meeting" → <Platform> submenu.
+        if let recordMeeting = AccessibilityHelper.findMenuItemByFuzzyTitle(
+            menuExtra, title: "Record Meeting"
+        ) {
+            DetectionLogger.shared.automation(
+                "Falling back to legacy Record Meeting submenu", action: "startRecording"
+            )
+            let expandErr = AXUIElementPerformAction(recordMeeting, kAXPressAction as CFString)
+            if expandErr == .success {
+                Thread.sleep(forTimeInterval: 0.3)
+                if let platformItem = AccessibilityHelper.findMenuItemByFuzzyTitle(
+                    recordMeeting, title: menuTitle
+                ) {
+                    let result = AccessibilityHelper.press(platformItem)
+                    if case .success = result {
+                        DetectionLogger.shared.automation(
+                            "Recording started for \(platform.displayName) (legacy submenu)",
+                            action: "startRecording"
+                        )
+                        return result
+                    }
+                    AXUIElementPerformAction(menuExtra, kAXCancelAction as CFString)
+                    return result
+                }
+            }
+        }
+
+        let seen = AccessibilityHelper.enumerateMenuItemTitles(menuExtra)
+        DetectionLogger.shared.error(
+            .automation,
+            "No 'Record \(menuTitle) Meeting' or 'Record Meeting > \(menuTitle)' found. Menu items: \(seen.joined(separator: ", "))"
+        )
+        AXUIElementPerformAction(menuExtra, kAXCancelAction as CFString)
+        return .failure(.elementNotFound(
+            description: "Record \(menuTitle) Meeting (saw: \(seen.joined(separator: ", ")))"
+        ))
     }
 
     /// Manual recording by raw button name.
@@ -277,8 +358,10 @@ final class MacWhisperController: Sendable {
         }
     }
 
-    /// Stop recording — press "Finish" on an existing finish-recording dialog,
-    /// or find the active recording in the sidebar to trigger the dialog first.
+    /// Stop recording. Current MacWhisper exposes a top-level "Stop Recording"
+    /// menu item in its status-menu extra — try that first. Older versions
+    /// instead surfaced a "Finish Recording" dialog (triggered by clicking the
+    /// active recording row in the sidebar), so we keep that path as a fallback.
     private func performStopRecording() -> Result<Void, AXError> {
         DetectionLogger.shared.automation("Stopping recording", action: "stopRecording")
 
@@ -286,33 +369,58 @@ final class MacWhisperController: Sendable {
         case .failure(let error):
             return .failure(error)
         case .success(let appElement):
-            // Step 1: Check for an existing "Finish Recording" dialog
+            if let result = pressStopRecordingMenuItem(appElement) {
+                return result
+            }
+
+            // Try in-window "Stop" button (AXDescription "Stop",
+            // help="Stop the meeting recording") — present on the recording
+            // meta-window in current MacWhisper.
+            let windows = AccessibilityHelper.arrayAttribute(appElement, kAXWindowsAttribute)
+            for window in windows {
+                guard let stopButton = AccessibilityHelper.findByDescription(
+                    window, description: "Stop"
+                ) else { continue }
+                let help: String = AccessibilityHelper.attribute(stopButton, kAXHelpAttribute) ?? ""
+                guard help.lowercased().contains("stop") && help.lowercased().contains("recording") else {
+                    continue
+                }
+                DetectionLogger.shared.automation(
+                    "Pressing in-window Stop button", action: "stopRecording"
+                )
+                let result = AccessibilityHelper.press(stopButton)
+                if case .success = result {
+                    DetectionLogger.shared.automation(
+                        "Recording stopped via in-window Stop", action: "stopRecording"
+                    )
+                    return result
+                }
+            }
+
+            // Legacy path: existing "Finish Recording" dialog.
             if let result = pressFinishDialogButton(appElement) {
                 return result
             }
 
-            // Step 2: Find the active recording row in the sidebar and select it
-            // to trigger the finish-recording dialog
-            let windows = AccessibilityHelper.arrayAttribute(appElement, kAXWindowsAttribute)
+            // Legacy path: trigger the dialog by selecting the active recording
+            // row, then press Finish on the resulting dialog.
             for window in windows {
                 if let activeRow = findActiveRecordingRow(window) {
                     DetectionLogger.shared.automation(
                         "Found active recording row, selecting to trigger stop dialog",
                         action: "stopRecording"
                     )
-                    // Selecting the row triggers the "Finish Recording?" dialog
                     AXUIElementPerformAction(activeRow, kAXPressAction as CFString)
-                    // Give the dialog time to appear
                     Thread.sleep(forTimeInterval: 0.5)
-
                     if let result = pressFinishDialogButton(appElement) {
                         return result
                     }
                 }
             }
 
-            // No dialog and no active recording row — MacWhisper isn't recording.
-            // Treat stop as idempotent so the app's state still clears to idle.
+            // No dialog, no active recording row, no menu item — MacWhisper
+            // isn't recording. Treat stop as idempotent so the app's state
+            // still clears to idle.
             DetectionLogger.shared.automation(
                 "No active recording found — treating stop as no-op", action: "stopRecording"
             )
@@ -320,59 +428,75 @@ final class MacWhisperController: Sendable {
         }
     }
 
-    /// Find and press the "Finish" button on a finish-recording dialog.
-    private func pressFinishDialogButton(_ appElement: AXUIElement) -> Result<Void, AXError>? {
-        let windows = AccessibilityHelper.arrayAttribute(appElement, kAXWindowsAttribute)
-        for window in windows {
-            let subrole: String? = AccessibilityHelper.attribute(window, kAXSubroleAttribute)
-            guard subrole == "AXSystemDialog" else { continue }
-
-            if let finishButton = AccessibilityHelper.findByDescription(
-                window, description: "Finish"
-            ) {
-                let result = AccessibilityHelper.press(finishButton)
-                switch result {
-                case .success:
-                    DetectionLogger.shared.automation(
-                        "Recording stopped via Finish button", action: "stopRecording"
-                    )
-                case .failure(let error):
-                    DetectionLogger.shared.error(
-                        .automation, "Failed to press Finish: \(error)"
-                    )
-                }
-                return result
-            }
+    /// Find and press the top-level "Stop Recording" item in MacWhisper's
+    /// status-menu extra. Returns `nil` when the item isn't present (caller
+    /// should fall through to legacy stop paths).
+    private func pressStopRecordingMenuItem(
+        _ appElement: AXUIElement
+    ) -> Result<Void, AXError>? {
+        guard let extras: AXUIElement =
+                AccessibilityHelper.attribute(appElement, kAXExtrasMenuBarAttribute),
+              let menuExtra = AccessibilityHelper.arrayAttribute(
+                extras, kAXChildrenAttribute
+              ).first else {
+            return nil
         }
-        return nil
+        // Passive read first — if "Stop Recording" isn't present, we're not
+        // recording (or this MacWhisper version uses the dialog instead).
+        guard AccessibilityHelper.findMenuItemByTitle(
+            menuExtra, title: "Stop Recording", maxDepth: 4
+        ) != nil else {
+            return nil
+        }
+        DetectionLogger.shared.automation(
+            "Opening MacWhisper menu extra to press Stop Recording", action: "stopRecording"
+        )
+        let openErr = AXUIElementPerformAction(menuExtra, kAXPressAction as CFString)
+        guard openErr == .success else { return nil }
+        Thread.sleep(forTimeInterval: 0.3)
+        guard let stopItem = AccessibilityHelper.findMenuItemByTitle(
+            menuExtra, title: "Stop Recording"
+        ) else {
+            AXUIElementPerformAction(menuExtra, kAXCancelAction as CFString)
+            return nil
+        }
+        let result = AccessibilityHelper.press(stopItem)
+        if case .success = result {
+            DetectionLogger.shared.automation(
+                "Recording stopped via menu extra", action: "stopRecording"
+            )
+        }
+        return result
     }
 
-    /// Find the active recording row in the sidebar (the cell containing "Meeting - ..." text).
-    private func findActiveRecordingRow(_ element: AXUIElement, depth: Int = 0) -> AXUIElement? {
-        guard depth < 15 else { return nil }
-        let role: String = AccessibilityHelper.attribute(element, kAXRoleAttribute) ?? ""
-        if role == "AXCell" {
-            for child in AccessibilityHelper.arrayAttribute(element, kAXChildrenAttribute) {
-                let value: String = AccessibilityHelper.attribute(child, kAXValueAttribute) ?? ""
-                if value.hasPrefix("Meeting") {
-                    return element
-                }
-            }
-        }
-        for child in AccessibilityHelper.arrayAttribute(element, kAXChildrenAttribute) {
-            if let found = findActiveRecordingRow(child, depth: depth + 1) {
-                return found
-            }
-        }
-        return nil
-    }
-
-    /// Check if recording — look for an active recording row in the sidebar.
+    /// Check if MacWhisper is currently recording. Prefers a passive read of
+    /// the status-menu extra (no menu open required — no menu-bar flash) and
+    /// falls back to scanning the sidebar.
+    ///
+    /// In the current MacWhisper, the menu extra contains either a
+    /// "Recording <Platform> Meeting" indicator + a "Stop Recording" action
+    /// when recording is active, or "Record <Platform> Meeting" when idle.
     private func performCheckRecording() -> Bool {
         switch createAppElement() {
         case .failure:
             return false
         case .success(let appElement):
+            // Passive menu-extra read — does not require opening the menu.
+            if let extras: AXUIElement =
+                    AccessibilityHelper.attribute(appElement, kAXExtrasMenuBarAttribute),
+               let menuExtra = AccessibilityHelper.arrayAttribute(
+                    extras, kAXChildrenAttribute
+               ).first {
+                let recordingItem = AccessibilityHelper.findMenuItemMatching(
+                    menuExtra, maxDepth: 4
+                ) { title in
+                    if title == "Stop Recording" { return true }
+                    return title.lowercased().hasPrefix("recording ")
+                }
+                if recordingItem != nil { return true }
+            }
+
+            // Fallback: sidebar scan (legacy MacWhisper layout).
             let windows = AccessibilityHelper.arrayAttribute(appElement, kAXWindowsAttribute)
             for window in windows {
                 if findActiveRecordingRow(window) != nil {


### PR DESCRIPTION
## Summary

MacWhisper's status-menu extra layout changed. The "Record Meeting" submenu is gone, replaced by:

- **`Record <Platform> Meeting`** — flat top-level item, only present when MacWhisper's own meeting detection picks up the platform
- **`Recording <Platform> Meeting`** + **`Stop Recording`** — top-level items present while recording is active
- The whole hierarchy is now readable **passively** (no menu open required)

Confirmed live in a real Teams meeting on the current MacWhisper build.

### Start recording
1. New flat **`Record <Platform> Meeting`** item (current MacWhisper)
2. Legacy **`Record Meeting`** → **`<Platform>`** submenu (older MacWhisper)
3. In-window **`Record <Platform>`** button by AXDescription — catches the case where our detector fired but MacWhisper's didn't (and is the reason the previous patch wasn't enough on its own)

### Stop recording
1. Top-level **`Stop Recording`** menu item (current MacWhisper)
2. In-window **`Stop`** button (help="Stop the meeting recording")
3. Legacy "Finish Recording" dialog flow — extracted to `MacWhisperController+LegacyStop.swift` to stay under SwiftLint's `type_body_length` cap

### Recording status check
- **Passive AX read** of the menu extra — looks for `Stop Recording` or any `Recording ...` item. No menu-open required → no menu-bar flash. Sidebar scan remains as a fallback for older MacWhisper.

### Other
- Added an "already recording" pre-check in `performStartRecording` so we don't trigger a duplicate when MacWhisper is already going (e.g. user started it manually, or a previous attempt's UI never updated).

## Test plan
- [x] Verified live in a Teams meeting: status flips from "Starting..." to "Recording Microsoft Teams" within ~2s of the AX poll cycle.
- [x] Confirmed pre-check skips duplicate start when MacWhisper is already recording.
- [x] Build passes (release bundle installed at `/Applications/MacWhisperAuto.app`).
- [ ] CI: SwiftLint `type_body_length` should pass (extracted legacy stop helpers to a separate file).
- [ ] Test Stop path end-to-end after this Teams meeting ends, or via Stop Recording button.
- [ ] Verify older MacWhisper paths still work for users who haven't updated (legacy submenu and dialog flow preserved).